### PR TITLE
fix: icon names typos

### DIFF
--- a/lib/src/amazing_icon_broken.dart
+++ b/lib/src/amazing_icon_broken.dart
@@ -734,8 +734,8 @@ class AmazingIconBroken {
   static const IconData filterSquare = IconData(0xf380, fontFamily: _kFontFam, fontPackage: _kFontPkg);
   /// Icon data for filterTick icon.
   static const IconData filterTick = IconData(0xf37f, fontFamily: _kFontFam, fontPackage: _kFontPkg);
-  /// Icon data for fingerCricle icon.
-  static const IconData fingerCricle = IconData(0xf37e, fontFamily: _kFontFam, fontPackage: _kFontPkg);
+  /// Icon data for fingerCircle icon.
+  static const IconData fingerCircle = IconData(0xf37e, fontFamily: _kFontFam, fontPackage: _kFontPkg);
   /// Icon data for fingerScan icon.
   static const IconData fingerScan = IconData(0xf37d, fontFamily: _kFontFam, fontPackage: _kFontPkg);
   /// Icon data for firstline icon.
@@ -882,8 +882,8 @@ class AmazingIconBroken {
   static const IconData gridLock = IconData(0xf336, fontFamily: _kFontFam, fontPackage: _kFontPkg);
   /// Icon data for group icon.
   static const IconData group = IconData(0xf335, fontFamily: _kFontFam, fontPackage: _kFontPkg);
-  /// Icon data for happyemoji icon.
-  static const IconData happyemoji = IconData(0xf334, fontFamily: _kFontFam, fontPackage: _kFontPkg);
+  /// Icon data for happyEmoji icon.
+  static const IconData happyEmoji = IconData(0xf334, fontFamily: _kFontFam, fontPackage: _kFontPkg);
   /// Icon data for harmony icon.
   static const IconData harmony = IconData(0xf333, fontFamily: _kFontFam, fontPackage: _kFontPkg);
   /// Icon data for hashtag icon.
@@ -1186,12 +1186,12 @@ class AmazingIconBroken {
   static const IconData microscope = IconData(0xf29e, fontFamily: _kFontFam, fontPackage: _kFontPkg);
   /// Icon data for milk icon.
   static const IconData milk = IconData(0xf29d, fontFamily: _kFontFam, fontPackage: _kFontPkg);
-  /// Icon data for miniMusicSqaure icon.
-  static const IconData miniMusicSqaure = IconData(0xf29c, fontFamily: _kFontFam, fontPackage: _kFontPkg);
+  /// Icon data for miniMusicSquare icon.
+  static const IconData miniMusicSquare = IconData(0xf29c, fontFamily: _kFontFam, fontPackage: _kFontPkg);
   /// Icon data for minus icon.
   static const IconData minus = IconData(0xf29b, fontFamily: _kFontFam, fontPackage: _kFontPkg);
-  /// Icon data for minusCirlce icon.
-  static const IconData minusCirlce = IconData(0xf29a, fontFamily: _kFontFam, fontPackage: _kFontPkg);
+  /// Icon data for minusCircle icon.
+  static const IconData minusCircle = IconData(0xf29a, fontFamily: _kFontFam, fontPackage: _kFontPkg);
   /// Icon data for minusSquare icon.
   static const IconData minusSquare = IconData(0xf299, fontFamily: _kFontFam, fontPackage: _kFontPkg);
   /// Icon data for mirror icon.
@@ -1232,8 +1232,8 @@ class AmazingIconBroken {
   static const IconData moneyTime = IconData(0xf288, fontFamily: _kFontFam, fontPackage: _kFontPkg);
   /// Icon data for monitor icon.
   static const IconData monitor = IconData(0xf286, fontFamily: _kFontFam, fontPackage: _kFontPkg);
-  /// Icon data for monitorMobbile icon.
-  static const IconData monitorMobbile = IconData(0xf285, fontFamily: _kFontFam, fontPackage: _kFontPkg);
+  /// Icon data for monitorMobile icon.
+  static const IconData monitorMobile = IconData(0xf285, fontFamily: _kFontFam, fontPackage: _kFontPkg);
   /// Icon data for monitorRecorder icon.
   static const IconData monitorRecorder = IconData(0xf284, fontFamily: _kFontFam, fontPackage: _kFontPkg);
   /// Icon data for moon icon.
@@ -1264,8 +1264,8 @@ class AmazingIconBroken {
   static const IconData musicFilter = IconData(0xf277, fontFamily: _kFontFam, fontPackage: _kFontPkg);
   /// Icon data for musicLibrary2 icon.
   static const IconData musicLibrary2 = IconData(0xf276, fontFamily: _kFontFam, fontPackage: _kFontPkg);
-  /// Icon data for musicnote icon.
-  static const IconData musicnote = IconData(0xf26f, fontFamily: _kFontFam, fontPackage: _kFontPkg);
+  /// Icon data for musicNote icon.
+  static const IconData musicNote = IconData(0xf26f, fontFamily: _kFontFam, fontPackage: _kFontPkg);
   /// Icon data for musicPlay icon.
   static const IconData musicPlay = IconData(0xf275, fontFamily: _kFontFam, fontPackage: _kFontPkg);
   /// Icon data for musicPlaylist icon.
@@ -1370,8 +1370,8 @@ class AmazingIconBroken {
   static const IconData personalcard = IconData(0xf242, fontFamily: _kFontFam, fontPackage: _kFontPkg);
   /// Icon data for pet icon.
   static const IconData pet = IconData(0xf241, fontFamily: _kFontFam, fontPackage: _kFontPkg);
-  /// Icon data for pharagraphspacing icon.
-  static const IconData pharagraphspacing = IconData(0xf240, fontFamily: _kFontFam, fontPackage: _kFontPkg);
+  /// Icon data for paragraphSpacing icon.
+  static const IconData paragraphSpacing = IconData(0xf240, fontFamily: _kFontFam, fontPackage: _kFontPkg);
   /// Icon data for photoshop icon.
   static const IconData photoshop = IconData(0xf23f, fontFamily: _kFontFam, fontPackage: _kFontPkg);
   /// Icon data for pictureFrame icon.
@@ -1382,8 +1382,8 @@ class AmazingIconBroken {
   static const IconData playAdd = IconData(0xf23c, fontFamily: _kFontFam, fontPackage: _kFontPkg);
   /// Icon data for playCircle icon.
   static const IconData playCircle = IconData(0xf23b, fontFamily: _kFontFam, fontPackage: _kFontPkg);
-  /// Icon data for playCricle icon.
-  static const IconData playCricle = IconData(0xf23a, fontFamily: _kFontFam, fontPackage: _kFontPkg);
+  /// Icon data for playCircle2 icon.
+  static const IconData playCircle2 = IconData(0xf23a, fontFamily: _kFontFam, fontPackage: _kFontPkg);
   /// Icon data for playRemove icon.
   static const IconData playRemove = IconData(0xf239, fontFamily: _kFontFam, fontPackage: _kFontPkg);
   /// Icon data for polkadot icon.
@@ -1392,8 +1392,8 @@ class AmazingIconBroken {
   static const IconData polygon = IconData(0xf237, fontFamily: _kFontFam, fontPackage: _kFontPkg);
   /// Icon data for polyswarm icon.
   static const IconData polyswarm = IconData(0xf236, fontFamily: _kFontFam, fontPackage: _kFontPkg);
-  /// Icon data for presentionChart icon.
-  static const IconData presentionChart = IconData(0xf235, fontFamily: _kFontFam, fontPackage: _kFontPkg);
+  /// Icon data for presentationChart icon.
+  static const IconData presentationChart = IconData(0xf235, fontFamily: _kFontFam, fontPackage: _kFontPkg);
   /// Icon data for previous icon.
   static const IconData previous = IconData(0xf234, fontFamily: _kFontFam, fontPackage: _kFontPkg);
   /// Icon data for printer icon.
@@ -1504,10 +1504,10 @@ class AmazingIconBroken {
   static const IconData repeat = IconData(0xf1ff, fontFamily: _kFontFam, fontPackage: _kFontPkg);
   /// Icon data for repeatCircle icon.
   static const IconData repeatCircle = IconData(0xf1fe, fontFamily: _kFontFam, fontPackage: _kFontPkg);
-  /// Icon data for repeateMusic icon.
-  static const IconData repeateMusic = IconData(0xf1fd, fontFamily: _kFontFam, fontPackage: _kFontPkg);
-  /// Icon data for repeateOne icon.
-  static const IconData repeateOne = IconData(0xf1fc, fontFamily: _kFontFam, fontPackage: _kFontPkg);
+  /// Icon data for repeatMusic icon.
+  static const IconData repeatMusic = IconData(0xf1fd, fontFamily: _kFontFam, fontPackage: _kFontPkg);
+  /// Icon data for repeatOne icon.
+  static const IconData repeatOne = IconData(0xf1fc, fontFamily: _kFontFam, fontPackage: _kFontPkg);
   /// Icon data for reserve icon.
   static const IconData reserve = IconData(0xf1fb, fontFamily: _kFontFam, fontPackage: _kFontPkg);
   /// Icon data for rotate3d icon.
@@ -1600,8 +1600,8 @@ class AmazingIconBroken {
   static const IconData send1 = IconData(0xf1cf, fontFamily: _kFontFam, fontPackage: _kFontPkg);
   /// Icon data for send2 icon.
   static const IconData send2 = IconData(0xf1ce, fontFamily: _kFontFam, fontPackage: _kFontPkg);
-  /// Icon data for sendSqaure2 icon.
-  static const IconData sendSqaure2 = IconData(0xf1cd, fontFamily: _kFontFam, fontPackage: _kFontPkg);
+  /// Icon data for sendSquare2 icon.
+  static const IconData sendSquare2 = IconData(0xf1cd, fontFamily: _kFontFam, fontPackage: _kFontPkg);
   /// Icon data for sendSquare icon.
   static const IconData sendSquare = IconData(0xf1cc, fontFamily: _kFontFam, fontPackage: _kFontPkg);
   /// Icon data for setting icon.

--- a/lib/src/amazing_icon_bulk.dart
+++ b/lib/src/amazing_icon_bulk.dart
@@ -6521,7 +6521,7 @@ class AmazingIconBulk {
   }) =>
       _build('filterTick', size: size, color: color, opacity: opacity);
 
-  /// Displays the `fingerCricle` bulk icon with a background and foreground layer.
+  /// Displays the `fingerCircle` bulk icon with a background and foreground layer.
   ///
   /// Parameters:
   /// - [size] icon size (default: 25).
@@ -6530,14 +6530,14 @@ class AmazingIconBulk {
   ///
   /// Example:
   /// ```dart
-  /// AmazingIconBulk.fingerCricle(size: 32, color: Colors.red);
+  /// AmazingIconBulk.fingerCircle(size: 32, color: Colors.red);
   /// ```
-  static Widget fingerCricle({
+  static Widget fingerCircle({
     double size = 25,
     Color color = Colors.black,
     double opacity = 0.4,
   }) =>
-      _build('fingerCricle', size: size, color: color, opacity: opacity);
+      _build('fingerCircle', size: size, color: color, opacity: opacity);
 
   /// Displays the `fingerScan` bulk icon with a background and foreground layer.
   ///
@@ -7817,7 +7817,7 @@ class AmazingIconBulk {
   }) =>
       _build('gridLock', size: size, color: color, opacity: opacity);
 
-  /// Displays the `happyemoji` bulk icon with a background and foreground layer.
+  /// Displays the `happyEmoji` bulk icon with a background and foreground layer.
   ///
   /// Parameters:
   /// - [size] icon size (default: 25).
@@ -7826,14 +7826,14 @@ class AmazingIconBulk {
   ///
   /// Example:
   /// ```dart
-  /// AmazingIconBulk.happyemoji(size: 32, color: Colors.red);
+  /// AmazingIconBulk.happyEmoji(size: 32, color: Colors.red);
   /// ```
-  static Widget happyemoji({
+  static Widget happyEmoji({
     double size = 25,
     Color color = Colors.black,
     double opacity = 0.4,
   }) =>
-      _build('happyemoji', size: size, color: color, opacity: opacity);
+      _build('happyEmoji', size: size, color: color, opacity: opacity);
 
   /// Displays the `harmony` bulk icon with a background and foreground layer.
   ///
@@ -10553,7 +10553,7 @@ class AmazingIconBulk {
   }) =>
       _build('milk', size: size, color: color, opacity: opacity);
 
-  /// Displays the `miniMusicSqaure` bulk icon with a background and foreground layer.
+  /// Displays the `miniMusicSquare` bulk icon with a background and foreground layer.
   ///
   /// Parameters:
   /// - [size] icon size (default: 25).
@@ -10562,14 +10562,14 @@ class AmazingIconBulk {
   ///
   /// Example:
   /// ```dart
-  /// AmazingIconBulk.miniMusicSqaure(size: 32, color: Colors.red);
+  /// AmazingIconBulk.miniMusicSquare(size: 32, color: Colors.red);
   /// ```
-  static Widget miniMusicSqaure({
+  static Widget miniMusicSquare({
     double size = 25,
     Color color = Colors.black,
     double opacity = 0.4,
   }) =>
-      _build('miniMusicSqaure', size: size, color: color, opacity: opacity);
+      _build('miniMusicSquare', size: size, color: color, opacity: opacity);
 
   /// Displays the `minus` bulk icon with a background and foreground layer.
   ///
@@ -10589,7 +10589,7 @@ class AmazingIconBulk {
   }) =>
       _build('minus', size: size, color: color, opacity: opacity);
 
-  /// Displays the `minusCirlce` bulk icon with a background and foreground layer.
+  /// Displays the `minusCircle` bulk icon with a background and foreground layer.
   ///
   /// Parameters:
   /// - [size] icon size (default: 25).
@@ -10598,14 +10598,14 @@ class AmazingIconBulk {
   ///
   /// Example:
   /// ```dart
-  /// AmazingIconBulk.minusCirlce(size: 32, color: Colors.red);
+  /// AmazingIconBulk.minusCircle(size: 32, color: Colors.red);
   /// ```
-  static Widget minusCirlce({
+  static Widget minusCircle({
     double size = 25,
     Color color = Colors.black,
     double opacity = 0.4,
   }) =>
-      _build('minusCirlce', size: size, color: color, opacity: opacity);
+      _build('minusCircle', size: size, color: color, opacity: opacity);
 
   /// Displays the `minusSquare` bulk icon with a background and foreground layer.
   ///
@@ -10967,7 +10967,7 @@ class AmazingIconBulk {
   }) =>
       _build('monitor', size: size, color: color, opacity: opacity);
 
-  /// Displays the `monitorMobbile` bulk icon with a background and foreground layer.
+  /// Displays the `monitorMobile` bulk icon with a background and foreground layer.
   ///
   /// Parameters:
   /// - [size] icon size (default: 25).
@@ -10976,14 +10976,14 @@ class AmazingIconBulk {
   ///
   /// Example:
   /// ```dart
-  /// AmazingIconBulk.monitorMobbile(size: 32, color: Colors.red);
+  /// AmazingIconBulk.monitorMobile(size: 32, color: Colors.red);
   /// ```
-  static Widget monitorMobbile({
+  static Widget monitorMobile({
     double size = 25,
     Color color = Colors.black,
     double opacity = 0.4,
   }) =>
-      _build('monitorMobbile', size: size, color: color, opacity: opacity);
+      _build('monitorMobile', size: size, color: color, opacity: opacity);
 
   /// Displays the `monitorRecorder` bulk icon with a background and foreground layer.
   ///
@@ -11363,7 +11363,7 @@ class AmazingIconBulk {
   }) =>
       _build('musicSquareSearch', size: size, color: color, opacity: opacity);
 
-  /// Displays the `musicnote` bulk icon with a background and foreground layer.
+  /// Displays the `musicNote` bulk icon with a background and foreground layer.
   ///
   /// Parameters:
   /// - [size] icon size (default: 25).
@@ -11372,14 +11372,14 @@ class AmazingIconBulk {
   ///
   /// Example:
   /// ```dart
-  /// AmazingIconBulk.musicnote(size: 32, color: Colors.red);
+  /// AmazingIconBulk.musicNote(size: 32, color: Colors.red);
   /// ```
-  static Widget musicnote({
+  static Widget musicNote({
     double size = 25,
     Color color = Colors.black,
     double opacity = 0.4,
   }) =>
-      _build('musicnote', size: size, color: color, opacity: opacity);
+      _build('musicNote', size: size, color: color, opacity: opacity);
 
   /// Displays the `nebulas` bulk icon with a background and foreground layer.
   ///
@@ -12209,7 +12209,7 @@ class AmazingIconBulk {
   }) =>
       _build('pet', size: size, color: color, opacity: opacity);
 
-  /// Displays the `pharagraphspacing` bulk icon with a background and foreground layer.
+  /// Displays the `paragraphSpacing` bulk icon with a background and foreground layer.
   ///
   /// Parameters:
   /// - [size] icon size (default: 25).
@@ -12218,14 +12218,14 @@ class AmazingIconBulk {
   ///
   /// Example:
   /// ```dart
-  /// AmazingIconBulk.pharagraphspacing(size: 32, color: Colors.red);
+  /// AmazingIconBulk.paragraphSpacing(size: 32, color: Colors.red);
   /// ```
-  static Widget pharagraphspacing({
+  static Widget paragraphSpacing({
     double size = 25,
     Color color = Colors.black,
     double opacity = 0.4,
   }) =>
-      _build('pharagraphspacing', size: size, color: color, opacity: opacity);
+      _build('paragraphSpacing', size: size, color: color, opacity: opacity);
 
   /// Displays the `photoshop` bulk icon with a background and foreground layer.
   ///
@@ -12317,7 +12317,7 @@ class AmazingIconBulk {
   }) =>
       _build('playCircle', size: size, color: color, opacity: opacity);
 
-  /// Displays the `playCricle` bulk icon with a background and foreground layer.
+  /// Displays the `playCircle2` bulk icon with a background and foreground layer.
   ///
   /// Parameters:
   /// - [size] icon size (default: 25).
@@ -12326,14 +12326,14 @@ class AmazingIconBulk {
   ///
   /// Example:
   /// ```dart
-  /// AmazingIconBulk.playCricle(size: 32, color: Colors.red);
+  /// AmazingIconBulk.playCircle2(size: 32, color: Colors.red);
   /// ```
-  static Widget playCricle({
+  static Widget playCircle2({
     double size = 25,
     Color color = Colors.black,
     double opacity = 0.4,
   }) =>
-      _build('playCricle', size: size, color: color, opacity: opacity);
+      _build('playCircle2', size: size, color: color, opacity: opacity);
 
   /// Displays the `playRemove` bulk icon with a background and foreground layer.
   ///
@@ -12407,7 +12407,7 @@ class AmazingIconBulk {
   }) =>
       _build('polyswarm', size: size, color: color, opacity: opacity);
 
-  /// Displays the `presentionChart` bulk icon with a background and foreground layer.
+  /// Displays the `presentationChart` bulk icon with a background and foreground layer.
   ///
   /// Parameters:
   /// - [size] icon size (default: 25).
@@ -12416,14 +12416,14 @@ class AmazingIconBulk {
   ///
   /// Example:
   /// ```dart
-  /// AmazingIconBulk.presentionChart(size: 32, color: Colors.red);
+  /// AmazingIconBulk.presentationChart(size: 32, color: Colors.red);
   /// ```
-  static Widget presentionChart({
+  static Widget presentationChart({
     double size = 25,
     Color color = Colors.black,
     double opacity = 0.4,
   }) =>
-      _build('presentionChart', size: size, color: color, opacity: opacity);
+      _build('presentationChart', size: size, color: color, opacity: opacity);
 
   /// Displays the `previous` bulk icon with a background and foreground layer.
   ///
@@ -13433,7 +13433,7 @@ class AmazingIconBulk {
   }) =>
       _build('repeatCircle', size: size, color: color, opacity: opacity);
 
-  /// Displays the `repeateMusic` bulk icon with a background and foreground layer.
+  /// Displays the `repeatMusic` bulk icon with a background and foreground layer.
   ///
   /// Parameters:
   /// - [size] icon size (default: 25).
@@ -13442,16 +13442,16 @@ class AmazingIconBulk {
   ///
   /// Example:
   /// ```dart
-  /// AmazingIconBulk.repeateMusic(size: 32, color: Colors.red);
+  /// AmazingIconBulk.repeatMusic(size: 32, color: Colors.red);
   /// ```
-  static Widget repeateMusic({
+  static Widget repeatMusic({
     double size = 25,
     Color color = Colors.black,
     double opacity = 0.4,
   }) =>
-      _build('repeateMusic', size: size, color: color, opacity: opacity);
+      _build('repeatMusic', size: size, color: color, opacity: opacity);
 
-  /// Displays the `repeateOne` bulk icon with a background and foreground layer.
+  /// Displays the `repeatOne` bulk icon with a background and foreground layer.
   ///
   /// Parameters:
   /// - [size] icon size (default: 25).
@@ -13460,14 +13460,14 @@ class AmazingIconBulk {
   ///
   /// Example:
   /// ```dart
-  /// AmazingIconBulk.repeateOne(size: 32, color: Colors.red);
+  /// AmazingIconBulk.repeatOne(size: 32, color: Colors.red);
   /// ```
-  static Widget repeateOne({
+  static Widget repeatOne({
     double size = 25,
     Color color = Colors.black,
     double opacity = 0.4,
   }) =>
-      _build('repeateOne', size: size, color: color, opacity: opacity);
+      _build('repeatOne', size: size, color: color, opacity: opacity);
 
   /// Displays the `reserve` bulk icon with a background and foreground layer.
   ///
@@ -14297,7 +14297,7 @@ class AmazingIconBulk {
   }) =>
       _build('send2', size: size, color: color, opacity: opacity);
 
-  /// Displays the `sendSqaure2` bulk icon with a background and foreground layer.
+  /// Displays the `sendSquare2` bulk icon with a background and foreground layer.
   ///
   /// Parameters:
   /// - [size] icon size (default: 25).
@@ -14306,14 +14306,14 @@ class AmazingIconBulk {
   ///
   /// Example:
   /// ```dart
-  /// AmazingIconBulk.sendSqaure2(size: 32, color: Colors.red);
+  /// AmazingIconBulk.sendSquare2(size: 32, color: Colors.red);
   /// ```
-  static Widget sendSqaure2({
+  static Widget sendSquare2({
     double size = 25,
     Color color = Colors.black,
     double opacity = 0.4,
   }) =>
-      _build('sendSqaure2', size: size, color: color, opacity: opacity);
+      _build('sendSquare2', size: size, color: color, opacity: opacity);
 
   /// Displays the `sendSquare` bulk icon with a background and foreground layer.
   ///

--- a/lib/src/amazing_icon_filled.dart
+++ b/lib/src/amazing_icon_filled.dart
@@ -732,8 +732,8 @@ class AmazingIconFilled {
   static const IconData filterSquare = IconData(0xf37f, fontFamily: _kFontFam, fontPackage: _kFontPkg);
   /// Icon data for filterTick icon.
   static const IconData filterTick = IconData(0xf37e, fontFamily: _kFontFam, fontPackage: _kFontPkg);
-  /// Icon data for fingerCricle icon.
-  static const IconData fingerCricle = IconData(0xf37d, fontFamily: _kFontFam, fontPackage: _kFontPkg);
+  /// Icon data for fingerCircle icon.
+  static const IconData fingerCircle = IconData(0xf37d, fontFamily: _kFontFam, fontPackage: _kFontPkg);
   /// Icon data for fingerScan icon.
   static const IconData fingerScan = IconData(0xf37c, fontFamily: _kFontFam, fontPackage: _kFontPkg);
   /// Icon data for firstline icon.
@@ -876,8 +876,8 @@ class AmazingIconFilled {
   static const IconData gridEraser = IconData(0xf337, fontFamily: _kFontFam, fontPackage: _kFontPkg);
   /// Icon data for gridLock icon.
   static const IconData gridLock = IconData(0xf336, fontFamily: _kFontFam, fontPackage: _kFontPkg);
-  /// Icon data for happyemoji icon.
-  static const IconData happyemoji = IconData(0xf335, fontFamily: _kFontFam, fontPackage: _kFontPkg);
+  /// Icon data for happyEmoji icon.
+  static const IconData happyEmoji = IconData(0xf335, fontFamily: _kFontFam, fontPackage: _kFontPkg);
   /// Icon data for harmony icon.
   static const IconData harmony = IconData(0xf334, fontFamily: _kFontFam, fontPackage: _kFontPkg);
   /// Icon data for hashtag icon.
@@ -1180,12 +1180,12 @@ class AmazingIconFilled {
   static const IconData microscope = IconData(0xf29f, fontFamily: _kFontFam, fontPackage: _kFontPkg);
   /// Icon data for milk icon.
   static const IconData milk = IconData(0xf29e, fontFamily: _kFontFam, fontPackage: _kFontPkg);
-  /// Icon data for miniMusicSqaure icon.
-  static const IconData miniMusicSqaure = IconData(0xf29d, fontFamily: _kFontFam, fontPackage: _kFontPkg);
+  /// Icon data for miniMusicSquare icon.
+  static const IconData miniMusicSquare = IconData(0xf29d, fontFamily: _kFontFam, fontPackage: _kFontPkg);
   /// Icon data for minus icon.
   static const IconData minus = IconData(0xf29c, fontFamily: _kFontFam, fontPackage: _kFontPkg);
-  /// Icon data for minusCirlce icon.
-  static const IconData minusCirlce = IconData(0xf29b, fontFamily: _kFontFam, fontPackage: _kFontPkg);
+  /// Icon data for minusCircle icon.
+  static const IconData minusCircle = IconData(0xf29b, fontFamily: _kFontFam, fontPackage: _kFontPkg);
   /// Icon data for minusSquare icon.
   static const IconData minusSquare = IconData(0xf29a, fontFamily: _kFontFam, fontPackage: _kFontPkg);
   /// Icon data for mirror icon.
@@ -1226,8 +1226,8 @@ class AmazingIconFilled {
   static const IconData moneyTime = IconData(0xf289, fontFamily: _kFontFam, fontPackage: _kFontPkg);
   /// Icon data for monitor icon.
   static const IconData monitor = IconData(0xf287, fontFamily: _kFontFam, fontPackage: _kFontPkg);
-  /// Icon data for monitorMobbile icon.
-  static const IconData monitorMobbile = IconData(0xf286, fontFamily: _kFontFam, fontPackage: _kFontPkg);
+  /// Icon data for monitorMobile icon.
+  static const IconData monitorMobile = IconData(0xf286, fontFamily: _kFontFam, fontPackage: _kFontPkg);
   /// Icon data for monitorRecorder icon.
   static const IconData monitorRecorder = IconData(0xf285, fontFamily: _kFontFam, fontPackage: _kFontPkg);
   /// Icon data for moon icon.
@@ -1258,8 +1258,8 @@ class AmazingIconFilled {
   static const IconData musicFilter = IconData(0xf278, fontFamily: _kFontFam, fontPackage: _kFontPkg);
   /// Icon data for musicLibrary2 icon.
   static const IconData musicLibrary2 = IconData(0xf277, fontFamily: _kFontFam, fontPackage: _kFontPkg);
-  /// Icon data for musicnote icon.
-  static const IconData musicnote = IconData(0xf270, fontFamily: _kFontFam, fontPackage: _kFontPkg);
+  /// Icon data for musicNote icon.
+  static const IconData musicNote = IconData(0xf270, fontFamily: _kFontFam, fontPackage: _kFontPkg);
   /// Icon data for musicPlay icon.
   static const IconData musicPlay = IconData(0xf276, fontFamily: _kFontFam, fontPackage: _kFontPkg);
   /// Icon data for musicPlaylist icon.
@@ -1364,8 +1364,8 @@ class AmazingIconFilled {
   static const IconData personalcard = IconData(0xf243, fontFamily: _kFontFam, fontPackage: _kFontPkg);
   /// Icon data for pet icon.
   static const IconData pet = IconData(0xf242, fontFamily: _kFontFam, fontPackage: _kFontPkg);
-  /// Icon data for pharagraphspacing icon.
-  static const IconData pharagraphspacing = IconData(0xf241, fontFamily: _kFontFam, fontPackage: _kFontPkg);
+  /// Icon data for paragraphSpacing icon.
+  static const IconData paragraphSpacing = IconData(0xf241, fontFamily: _kFontFam, fontPackage: _kFontPkg);
   /// Icon data for photoshop icon.
   static const IconData photoshop = IconData(0xf240, fontFamily: _kFontFam, fontPackage: _kFontPkg);
   /// Icon data for pictureFrame icon.
@@ -1376,8 +1376,8 @@ class AmazingIconFilled {
   static const IconData playAdd = IconData(0xf23d, fontFamily: _kFontFam, fontPackage: _kFontPkg);
   /// Icon data for playCircle icon.
   static const IconData playCircle = IconData(0xf23c, fontFamily: _kFontFam, fontPackage: _kFontPkg);
-  /// Icon data for playCricle icon.
-  static const IconData playCricle = IconData(0xf23b, fontFamily: _kFontFam, fontPackage: _kFontPkg);
+  /// Icon data for playCircle2 icon.
+  static const IconData playCircle2 = IconData(0xf23b, fontFamily: _kFontFam, fontPackage: _kFontPkg);
   /// Icon data for playRemove icon.
   static const IconData playRemove = IconData(0xf23a, fontFamily: _kFontFam, fontPackage: _kFontPkg);
   /// Icon data for polkadot icon.
@@ -1386,8 +1386,8 @@ class AmazingIconFilled {
   static const IconData polygon = IconData(0xf238, fontFamily: _kFontFam, fontPackage: _kFontPkg);
   /// Icon data for polyswarm icon.
   static const IconData polyswarm = IconData(0xf237, fontFamily: _kFontFam, fontPackage: _kFontPkg);
-  /// Icon data for presentionChart icon.
-  static const IconData presentionChart = IconData(0xf236, fontFamily: _kFontFam, fontPackage: _kFontPkg);
+  /// Icon data for presentationChart icon.
+  static const IconData presentationChart = IconData(0xf236, fontFamily: _kFontFam, fontPackage: _kFontPkg);
   /// Icon data for previous icon.
   static const IconData previous = IconData(0xf235, fontFamily: _kFontFam, fontPackage: _kFontPkg);
   /// Icon data for printer icon.
@@ -1500,10 +1500,10 @@ class AmazingIconFilled {
   static const IconData repeat = IconData(0xf1ff, fontFamily: _kFontFam, fontPackage: _kFontPkg);
   /// Icon data for repeatCircle icon.
   static const IconData repeatCircle = IconData(0xf1fe, fontFamily: _kFontFam, fontPackage: _kFontPkg);
-  /// Icon data for repeateMusic icon.
-  static const IconData repeateMusic = IconData(0xf1fd, fontFamily: _kFontFam, fontPackage: _kFontPkg);
-  /// Icon data for repeateOne icon.
-  static const IconData repeateOne = IconData(0xf1fc, fontFamily: _kFontFam, fontPackage: _kFontPkg);
+  /// Icon data for repeatMusic icon.
+  static const IconData repeatMusic = IconData(0xf1fd, fontFamily: _kFontFam, fontPackage: _kFontPkg);
+  /// Icon data for repeatOne icon.
+  static const IconData repeatOne = IconData(0xf1fc, fontFamily: _kFontFam, fontPackage: _kFontPkg);
   /// Icon data for reserve icon.
   static const IconData reserve = IconData(0xf1fb, fontFamily: _kFontFam, fontPackage: _kFontPkg);
   /// Icon data for rotate3d icon.
@@ -1594,8 +1594,8 @@ class AmazingIconFilled {
   static const IconData send1 = IconData(0xf1d0, fontFamily: _kFontFam, fontPackage: _kFontPkg);
   /// Icon data for send2 icon.
   static const IconData send2 = IconData(0xf1cf, fontFamily: _kFontFam, fontPackage: _kFontPkg);
-  /// Icon data for sendSqaure2 icon.
-  static const IconData sendSqaure2 = IconData(0xf1ce, fontFamily: _kFontFam, fontPackage: _kFontPkg);
+  /// Icon data for sendSquare2 icon.
+  static const IconData sendSquare2 = IconData(0xf1ce, fontFamily: _kFontFam, fontPackage: _kFontPkg);
   /// Icon data for sendSquare icon.
   static const IconData sendSquare = IconData(0xf1cd, fontFamily: _kFontFam, fontPackage: _kFontPkg);
   /// Icon data for setting icon.

--- a/lib/src/amazing_icon_outlined.dart
+++ b/lib/src/amazing_icon_outlined.dart
@@ -734,8 +734,8 @@ class AmazingIconOutlined {
   static const IconData filterSquare = IconData(0xf380, fontFamily: _kFontFam, fontPackage: _kFontPkg);
   /// Icon data for filterTick icon.
   static const IconData filterTick = IconData(0xf37f, fontFamily: _kFontFam, fontPackage: _kFontPkg);
-  /// Icon data for fingerCricle icon.
-  static const IconData fingerCricle = IconData(0xf37e, fontFamily: _kFontFam, fontPackage: _kFontPkg);
+  /// Icon data for fingerCircle icon.
+  static const IconData fingerCircle = IconData(0xf37e, fontFamily: _kFontFam, fontPackage: _kFontPkg);
   /// Icon data for fingerScan icon.
   static const IconData fingerScan = IconData(0xf37d, fontFamily: _kFontFam, fontPackage: _kFontPkg);
   /// Icon data for firstline icon.
@@ -878,8 +878,8 @@ class AmazingIconOutlined {
   static const IconData gridEraser = IconData(0xf338, fontFamily: _kFontFam, fontPackage: _kFontPkg);
   /// Icon data for gridLock icon.
   static const IconData gridLock = IconData(0xf337, fontFamily: _kFontFam, fontPackage: _kFontPkg);
-  /// Icon data for happyemoji icon.
-  static const IconData happyemoji = IconData(0xf336, fontFamily: _kFontFam, fontPackage: _kFontPkg);
+  /// Icon data for happyEmoji icon.
+  static const IconData happyEmoji = IconData(0xf336, fontFamily: _kFontFam, fontPackage: _kFontPkg);
   /// Icon data for harmony icon.
   static const IconData harmony = IconData(0xf335, fontFamily: _kFontFam, fontPackage: _kFontPkg);
   /// Icon data for hashtag icon.
@@ -1182,12 +1182,12 @@ class AmazingIconOutlined {
   static const IconData microscope = IconData(0xf2a0, fontFamily: _kFontFam, fontPackage: _kFontPkg);
   /// Icon data for milk icon.
   static const IconData milk = IconData(0xf29f, fontFamily: _kFontFam, fontPackage: _kFontPkg);
-  /// Icon data for miniMusicSqaure icon.
-  static const IconData miniMusicSqaure = IconData(0xf29e, fontFamily: _kFontFam, fontPackage: _kFontPkg);
+  /// Icon data for miniMusicSquare icon.
+  static const IconData miniMusicSquare = IconData(0xf29e, fontFamily: _kFontFam, fontPackage: _kFontPkg);
   /// Icon data for minus icon.
   static const IconData minus = IconData(0xf29d, fontFamily: _kFontFam, fontPackage: _kFontPkg);
-  /// Icon data for minusCirlce icon.
-  static const IconData minusCirlce = IconData(0xf29c, fontFamily: _kFontFam, fontPackage: _kFontPkg);
+  /// Icon data for minusCircle icon.
+  static const IconData minusCircle = IconData(0xf29c, fontFamily: _kFontFam, fontPackage: _kFontPkg);
   /// Icon data for minusSquare icon.
   static const IconData minusSquare = IconData(0xf29b, fontFamily: _kFontFam, fontPackage: _kFontPkg);
   /// Icon data for mirror icon.
@@ -1228,8 +1228,8 @@ class AmazingIconOutlined {
   static const IconData moneyTime = IconData(0xf28a, fontFamily: _kFontFam, fontPackage: _kFontPkg);
   /// Icon data for monitor icon.
   static const IconData monitor = IconData(0xf288, fontFamily: _kFontFam, fontPackage: _kFontPkg);
-  /// Icon data for monitorMobbile icon.
-  static const IconData monitorMobbile = IconData(0xf287, fontFamily: _kFontFam, fontPackage: _kFontPkg);
+  /// Icon data for monitorMobile icon.
+  static const IconData monitorMobile = IconData(0xf287, fontFamily: _kFontFam, fontPackage: _kFontPkg);
   /// Icon data for monitorRecorder icon.
   static const IconData monitorRecorder = IconData(0xf286, fontFamily: _kFontFam, fontPackage: _kFontPkg);
   /// Icon data for moon icon.
@@ -1260,8 +1260,8 @@ class AmazingIconOutlined {
   static const IconData musicFilter = IconData(0xf279, fontFamily: _kFontFam, fontPackage: _kFontPkg);
   /// Icon data for musicLibrary2 icon.
   static const IconData musicLibrary2 = IconData(0xf278, fontFamily: _kFontFam, fontPackage: _kFontPkg);
-  /// Icon data for musicnote icon.
-  static const IconData musicnote = IconData(0xf271, fontFamily: _kFontFam, fontPackage: _kFontPkg);
+  /// Icon data for musicNote icon.
+  static const IconData musicNote = IconData(0xf271, fontFamily: _kFontFam, fontPackage: _kFontPkg);
   /// Icon data for musicPlay icon.
   static const IconData musicPlay = IconData(0xf277, fontFamily: _kFontFam, fontPackage: _kFontPkg);
   /// Icon data for musicPlaylist icon.
@@ -1366,8 +1366,8 @@ class AmazingIconOutlined {
   static const IconData personalcard = IconData(0xf244, fontFamily: _kFontFam, fontPackage: _kFontPkg);
   /// Icon data for pet icon.
   static const IconData pet = IconData(0xf243, fontFamily: _kFontFam, fontPackage: _kFontPkg);
-  /// Icon data for pharagraphspacing icon.
-  static const IconData pharagraphspacing = IconData(0xf242, fontFamily: _kFontFam, fontPackage: _kFontPkg);
+  /// Icon data for paragraphSpacing icon.
+  static const IconData paragraphSpacing = IconData(0xf242, fontFamily: _kFontFam, fontPackage: _kFontPkg);
   /// Icon data for photoshop icon.
   static const IconData photoshop = IconData(0xf241, fontFamily: _kFontFam, fontPackage: _kFontPkg);
   /// Icon data for pictureFrame icon.
@@ -1378,8 +1378,8 @@ class AmazingIconOutlined {
   static const IconData playAdd = IconData(0xf23e, fontFamily: _kFontFam, fontPackage: _kFontPkg);
   /// Icon data for playCircle icon.
   static const IconData playCircle = IconData(0xf23d, fontFamily: _kFontFam, fontPackage: _kFontPkg);
-  /// Icon data for playCricle icon.
-  static const IconData playCricle = IconData(0xf23c, fontFamily: _kFontFam, fontPackage: _kFontPkg);
+  /// Icon data for playCircle2 icon.
+  static const IconData playCircle2 = IconData(0xf23c, fontFamily: _kFontFam, fontPackage: _kFontPkg);
   /// Icon data for playRemove icon.
   static const IconData playRemove = IconData(0xf23b, fontFamily: _kFontFam, fontPackage: _kFontPkg);
   /// Icon data for polkadot icon.
@@ -1388,8 +1388,8 @@ class AmazingIconOutlined {
   static const IconData polygon = IconData(0xf239, fontFamily: _kFontFam, fontPackage: _kFontPkg);
   /// Icon data for polyswarm icon.
   static const IconData polyswarm = IconData(0xf238, fontFamily: _kFontFam, fontPackage: _kFontPkg);
-  /// Icon data for presentionChart icon.
-  static const IconData presentionChart = IconData(0xf237, fontFamily: _kFontFam, fontPackage: _kFontPkg);
+  /// Icon data for presentationChart icon.
+  static const IconData presentationChart = IconData(0xf237, fontFamily: _kFontFam, fontPackage: _kFontPkg);
   /// Icon data for previous icon.
   static const IconData previous = IconData(0xf236, fontFamily: _kFontFam, fontPackage: _kFontPkg);
   /// Icon data for printer icon.
@@ -1502,10 +1502,10 @@ class AmazingIconOutlined {
   static const IconData repeat = IconData(0xf200, fontFamily: _kFontFam, fontPackage: _kFontPkg);
   /// Icon data for repeatCircle icon.
   static const IconData repeatCircle = IconData(0xf1ff, fontFamily: _kFontFam, fontPackage: _kFontPkg);
-  /// Icon data for repeateMusic icon.
-  static const IconData repeateMusic = IconData(0xf1fe, fontFamily: _kFontFam, fontPackage: _kFontPkg);
-  /// Icon data for repeateOne icon.
-  static const IconData repeateOne = IconData(0xf1fd, fontFamily: _kFontFam, fontPackage: _kFontPkg);
+  /// Icon data for repeatMusic icon.
+  static const IconData repeatMusic = IconData(0xf1fe, fontFamily: _kFontFam, fontPackage: _kFontPkg);
+  /// Icon data for repeatOne icon.
+  static const IconData repeatOne = IconData(0xf1fd, fontFamily: _kFontFam, fontPackage: _kFontPkg);
   /// Icon data for reserve icon.
   static const IconData reserve = IconData(0xf1fc, fontFamily: _kFontFam, fontPackage: _kFontPkg);
   /// Icon data for rotate3d icon.
@@ -1598,8 +1598,8 @@ class AmazingIconOutlined {
   static const IconData send1 = IconData(0xf1d0, fontFamily: _kFontFam, fontPackage: _kFontPkg);
   /// Icon data for send2 icon.
   static const IconData send2 = IconData(0xf1cf, fontFamily: _kFontFam, fontPackage: _kFontPkg);
-  /// Icon data for sendSqaure2 icon.
-  static const IconData sendSqaure2 = IconData(0xf1ce, fontFamily: _kFontFam, fontPackage: _kFontPkg);
+  /// Icon data for sendSquare2 icon.
+  static const IconData sendSquare2 = IconData(0xf1ce, fontFamily: _kFontFam, fontPackage: _kFontPkg);
   /// Icon data for sendSquare icon.
   static const IconData sendSquare = IconData(0xf1cd, fontFamily: _kFontFam, fontPackage: _kFontPkg);
   /// Icon data for setting icon.

--- a/lib/src/amazing_icon_twotone.dart
+++ b/lib/src/amazing_icon_twotone.dart
@@ -6142,7 +6142,7 @@ class AmazingIconTwotone {
   }) =>
       _build('filterTick', size: size, color: color, opacity: opacity);
 
-  /// Displays the `fingerCricle` twotone icon with a background and foreground layer.
+  /// Displays the `fingerCircle` twotone icon with a background and foreground layer.
   ///
   /// Parameters:
   /// - [size] icon size (default: 25).
@@ -6151,14 +6151,14 @@ class AmazingIconTwotone {
   ///
   /// Example:
   /// ```dart
-  /// AmazingIconTwotone.fingerCricle(size: 32, color: Colors.red);
+  /// AmazingIconTwotone.fingerCircle(size: 32, color: Colors.red);
   /// ```
-  static Widget fingerCricle({
+  static Widget fingerCircle({
     double size = 25,
     Color color = Colors.black,
     double opacity = 0.4,
   }) =>
-      _build('fingerCricle', size: size, color: color, opacity: opacity);
+      _build('fingerCircle', size: size, color: color, opacity: opacity);
 
   /// Displays the `fingerScan` twotone icon with a background and foreground layer.
   ///
@@ -7366,7 +7366,7 @@ class AmazingIconTwotone {
   }) =>
       _build('gridLock', size: size, color: color, opacity: opacity);
 
-  /// Displays the `happyemoji` twotone icon with a background and foreground layer.
+  /// Displays the `happyEmoji` twotone icon with a background and foreground layer.
   ///
   /// Parameters:
   /// - [size] icon size (default: 25).
@@ -7375,14 +7375,14 @@ class AmazingIconTwotone {
   ///
   /// Example:
   /// ```dart
-  /// AmazingIconTwotone.happyemoji(size: 32, color: Colors.red);
+  /// AmazingIconTwotone.happyEmoji(size: 32, color: Colors.red);
   /// ```
-  static Widget happyemoji({
+  static Widget happyEmoji({
     double size = 25,
     Color color = Colors.black,
     double opacity = 0.4,
   }) =>
-      _build('happyemoji', size: size, color: color, opacity: opacity);
+      _build('happyEmoji', size: size, color: color, opacity: opacity);
 
   /// Displays the `harmony` twotone icon with a background and foreground layer.
   ///
@@ -10066,7 +10066,7 @@ class AmazingIconTwotone {
   }) =>
       _build('milk', size: size, color: color, opacity: opacity);
 
-  /// Displays the `miniMusicSqaure` twotone icon with a background and foreground layer.
+  /// Displays the `miniMusicSquare` twotone icon with a background and foreground layer.
   ///
   /// Parameters:
   /// - [size] icon size (default: 25).
@@ -10075,16 +10075,16 @@ class AmazingIconTwotone {
   ///
   /// Example:
   /// ```dart
-  /// AmazingIconTwotone.miniMusicSqaure(size: 32, color: Colors.red);
+  /// AmazingIconTwotone.miniMusicSquare(size: 32, color: Colors.red);
   /// ```
-  static Widget miniMusicSqaure({
+  static Widget miniMusicSquare({
     double size = 25,
     Color color = Colors.black,
     double opacity = 0.4,
   }) =>
-      _build('miniMusicSqaure', size: size, color: color, opacity: opacity);
+      _build('miniMusicSquare', size: size, color: color, opacity: opacity);
 
-  /// Displays the `minusCirlce` twotone icon with a background and foreground layer.
+  /// Displays the `minusCircle` twotone icon with a background and foreground layer.
   ///
   /// Parameters:
   /// - [size] icon size (default: 25).
@@ -10093,14 +10093,14 @@ class AmazingIconTwotone {
   ///
   /// Example:
   /// ```dart
-  /// AmazingIconTwotone.minusCirlce(size: 32, color: Colors.red);
+  /// AmazingIconTwotone.minusCircle(size: 32, color: Colors.red);
   /// ```
-  static Widget minusCirlce({
+  static Widget minusCircle({
     double size = 25,
     Color color = Colors.black,
     double opacity = 0.4,
   }) =>
-      _build('minusCirlce', size: size, color: color, opacity: opacity);
+      _build('minusCircle', size: size, color: color, opacity: opacity);
 
   /// Displays the `minusSquare` twotone icon with a background and foreground layer.
   ///
@@ -10462,7 +10462,7 @@ class AmazingIconTwotone {
   }) =>
       _build('monitor', size: size, color: color, opacity: opacity);
 
-  /// Displays the `monitorMobbile` twotone icon with a background and foreground layer.
+  /// Displays the `monitorMobile` twotone icon with a background and foreground layer.
   ///
   /// Parameters:
   /// - [size] icon size (default: 25).
@@ -10471,14 +10471,14 @@ class AmazingIconTwotone {
   ///
   /// Example:
   /// ```dart
-  /// AmazingIconTwotone.monitorMobbile(size: 32, color: Colors.red);
+  /// AmazingIconTwotone.monitorMobile(size: 32, color: Colors.red);
   /// ```
-  static Widget monitorMobbile({
+  static Widget monitorMobile({
     double size = 25,
     Color color = Colors.black,
     double opacity = 0.4,
   }) =>
-      _build('monitorMobbile', size: size, color: color, opacity: opacity);
+      _build('monitorMobile', size: size, color: color, opacity: opacity);
 
   /// Displays the `monitorRecorder` twotone icon with a background and foreground layer.
   ///
@@ -10840,7 +10840,7 @@ class AmazingIconTwotone {
   }) =>
       _build('musicSquareSearch', size: size, color: color, opacity: opacity);
 
-  /// Displays the `musicnote` twotone icon with a background and foreground layer.
+  /// Displays the `musicNote` twotone icon with a background and foreground layer.
   ///
   /// Parameters:
   /// - [size] icon size (default: 25).
@@ -10849,14 +10849,14 @@ class AmazingIconTwotone {
   ///
   /// Example:
   /// ```dart
-  /// AmazingIconTwotone.musicnote(size: 32, color: Colors.red);
+  /// AmazingIconTwotone.musicNote(size: 32, color: Colors.red);
   /// ```
-  static Widget musicnote({
+  static Widget musicNote({
     double size = 25,
     Color color = Colors.black,
     double opacity = 0.4,
   }) =>
-      _build('musicnote', size: size, color: color, opacity: opacity);
+      _build('musicNote', size: size, color: color, opacity: opacity);
 
   /// Displays the `nebulas` twotone icon with a background and foreground layer.
   ///
@@ -11650,7 +11650,7 @@ class AmazingIconTwotone {
   }) =>
       _build('pet', size: size, color: color, opacity: opacity);
 
-  /// Displays the `pharagraphspacing` twotone icon with a background and foreground layer.
+  /// Displays the `paragraphSpacing` twotone icon with a background and foreground layer.
   ///
   /// Parameters:
   /// - [size] icon size (default: 25).
@@ -11659,14 +11659,14 @@ class AmazingIconTwotone {
   ///
   /// Example:
   /// ```dart
-  /// AmazingIconTwotone.pharagraphspacing(size: 32, color: Colors.red);
+  /// AmazingIconTwotone.paragraphSpacing(size: 32, color: Colors.red);
   /// ```
-  static Widget pharagraphspacing({
+  static Widget paragraphSpacing({
     double size = 25,
     Color color = Colors.black,
     double opacity = 0.4,
   }) =>
-      _build('pharagraphspacing', size: size, color: color, opacity: opacity);
+      _build('paragraphSpacing', size: size, color: color, opacity: opacity);
 
   /// Displays the `photoshop` twotone icon with a background and foreground layer.
   ///
@@ -11740,7 +11740,7 @@ class AmazingIconTwotone {
   }) =>
       _build('playCircle', size: size, color: color, opacity: opacity);
 
-  /// Displays the `playCricle` twotone icon with a background and foreground layer.
+  /// Displays the `playCircle2` twotone icon with a background and foreground layer.
   ///
   /// Parameters:
   /// - [size] icon size (default: 25).
@@ -11749,14 +11749,14 @@ class AmazingIconTwotone {
   ///
   /// Example:
   /// ```dart
-  /// AmazingIconTwotone.playCricle(size: 32, color: Colors.red);
+  /// AmazingIconTwotone.playCircle2(size: 32, color: Colors.red);
   /// ```
-  static Widget playCricle({
+  static Widget playCircle2({
     double size = 25,
     Color color = Colors.black,
     double opacity = 0.4,
   }) =>
-      _build('playCricle', size: size, color: color, opacity: opacity);
+      _build('playCircle2', size: size, color: color, opacity: opacity);
 
   /// Displays the `playRemove` twotone icon with a background and foreground layer.
   ///
@@ -11830,7 +11830,7 @@ class AmazingIconTwotone {
   }) =>
       _build('polyswarm', size: size, color: color, opacity: opacity);
 
-  /// Displays the `presentionChart` twotone icon with a background and foreground layer.
+  /// Displays the `presentationChart` twotone icon with a background and foreground layer.
   ///
   /// Parameters:
   /// - [size] icon size (default: 25).
@@ -11839,14 +11839,14 @@ class AmazingIconTwotone {
   ///
   /// Example:
   /// ```dart
-  /// AmazingIconTwotone.presentionChart(size: 32, color: Colors.red);
+  /// AmazingIconTwotone.presentationChart(size: 32, color: Colors.red);
   /// ```
-  static Widget presentionChart({
+  static Widget presentationChart({
     double size = 25,
     Color color = Colors.black,
     double opacity = 0.4,
   }) =>
-      _build('presentionChart', size: size, color: color, opacity: opacity);
+      _build('presentationChart', size: size, color: color, opacity: opacity);
 
   /// Displays the `previous` twotone icon with a background and foreground layer.
   ///
@@ -12820,7 +12820,7 @@ class AmazingIconTwotone {
   }) =>
       _build('repeatCircle', size: size, color: color, opacity: opacity);
 
-  /// Displays the `repeateMusic` twotone icon with a background and foreground layer.
+  /// Displays the `repeatMusic` twotone icon with a background and foreground layer.
   ///
   /// Parameters:
   /// - [size] icon size (default: 25).
@@ -12829,16 +12829,16 @@ class AmazingIconTwotone {
   ///
   /// Example:
   /// ```dart
-  /// AmazingIconTwotone.repeateMusic(size: 32, color: Colors.red);
+  /// AmazingIconTwotone.repeatMusic(size: 32, color: Colors.red);
   /// ```
-  static Widget repeateMusic({
+  static Widget repeatMusic({
     double size = 25,
     Color color = Colors.black,
     double opacity = 0.4,
   }) =>
-      _build('repeateMusic', size: size, color: color, opacity: opacity);
+      _build('repeatMusic', size: size, color: color, opacity: opacity);
 
-  /// Displays the `repeateOne` twotone icon with a background and foreground layer.
+  /// Displays the `repeatOne` twotone icon with a background and foreground layer.
   ///
   /// Parameters:
   /// - [size] icon size (default: 25).
@@ -12847,14 +12847,14 @@ class AmazingIconTwotone {
   ///
   /// Example:
   /// ```dart
-  /// AmazingIconTwotone.repeateOne(size: 32, color: Colors.red);
+  /// AmazingIconTwotone.repeatOne(size: 32, color: Colors.red);
   /// ```
-  static Widget repeateOne({
+  static Widget repeatOne({
     double size = 25,
     Color color = Colors.black,
     double opacity = 0.4,
   }) =>
-      _build('repeateOne', size: size, color: color, opacity: opacity);
+      _build('repeatOne', size: size, color: color, opacity: opacity);
 
   /// Displays the `reserve` twotone icon with a background and foreground layer.
   ///
@@ -13684,7 +13684,7 @@ class AmazingIconTwotone {
   }) =>
       _build('send2', size: size, color: color, opacity: opacity);
 
-  /// Displays the `sendSqaure2` twotone icon with a background and foreground layer.
+  /// Displays the `sendSquare2` twotone icon with a background and foreground layer.
   ///
   /// Parameters:
   /// - [size] icon size (default: 25).
@@ -13693,14 +13693,14 @@ class AmazingIconTwotone {
   ///
   /// Example:
   /// ```dart
-  /// AmazingIconTwotone.sendSqaure2(size: 32, color: Colors.red);
+  /// AmazingIconTwotone.sendSquare2(size: 32, color: Colors.red);
   /// ```
-  static Widget sendSqaure2({
+  static Widget sendSquare2({
     double size = 25,
     Color color = Colors.black,
     double opacity = 0.4,
   }) =>
-      _build('sendSqaure2', size: size, color: color, opacity: opacity);
+      _build('sendSquare2', size: size, color: color, opacity: opacity);
 
   /// Displays the `sendSquare` twotone icon with a background and foreground layer.
   ///

--- a/lib/src/components/amazing_icon_bulk_bg.dart
+++ b/lib/src/components/amazing_icon_bulk_bg.dart
@@ -1091,8 +1091,8 @@ class _AmazingIconBulkBg {
   /// Icon data for filterTickBg icon.
   static const IconData filterTickBg = IconData(0xf37f, fontFamily: _kFontFam, fontPackage: _kFontPkg);
 
-  /// Icon data for fingerCricleBg icon.
-  static const IconData fingerCricleBg = IconData(0xf37d, fontFamily: _kFontFam, fontPackage: _kFontPkg);
+  /// Icon data for fingerCircleBg icon.
+  static const IconData fingerCircleBg = IconData(0xf37d, fontFamily: _kFontFam, fontPackage: _kFontPkg);
 
   /// Icon data for fingerScanBg icon.
   static const IconData fingerScanBg = IconData(0xf37c, fontFamily: _kFontFam, fontPackage: _kFontPkg);
@@ -1307,8 +1307,8 @@ class _AmazingIconBulkBg {
   /// Icon data for gridLockBg icon.
   static const IconData gridLockBg = IconData(0xf336, fontFamily: _kFontFam, fontPackage: _kFontPkg);
 
-  /// Icon data for happyemojiBg icon.
-  static const IconData happyemojiBg = IconData(0xf335, fontFamily: _kFontFam, fontPackage: _kFontPkg);
+  /// Icon data for happyEmojiBg icon.
+  static const IconData happyEmojiBg = IconData(0xf335, fontFamily: _kFontFam, fontPackage: _kFontPkg);
 
   /// Icon data for harmonyBg icon.
   static const IconData harmonyBg = IconData(0xf334, fontFamily: _kFontFam, fontPackage: _kFontPkg);
@@ -1763,14 +1763,14 @@ class _AmazingIconBulkBg {
   /// Icon data for milkBg icon.
   static const IconData milkBg = IconData(0xf29e, fontFamily: _kFontFam, fontPackage: _kFontPkg);
 
-  /// Icon data for miniMusicSqaureBg icon.
-  static const IconData miniMusicSqaureBg = IconData(0xf29d, fontFamily: _kFontFam, fontPackage: _kFontPkg);
+  /// Icon data for miniMusicSquareBg icon.
+  static const IconData miniMusicSquareBg = IconData(0xf29d, fontFamily: _kFontFam, fontPackage: _kFontPkg);
 
   /// Icon data for minusBg icon.
   static const IconData minusBg = IconData(0xf29a, fontFamily: _kFontFam, fontPackage: _kFontPkg);
 
-  /// Icon data for minusCirlceBg icon.
-  static const IconData minusCirlceBg = IconData(0xf29c, fontFamily: _kFontFam, fontPackage: _kFontPkg);
+  /// Icon data for minusCircleBg icon.
+  static const IconData minusCircleBg = IconData(0xf29c, fontFamily: _kFontFam, fontPackage: _kFontPkg);
 
   /// Icon data for minusSquareBg icon.
   static const IconData minusSquareBg = IconData(0xf29b, fontFamily: _kFontFam, fontPackage: _kFontPkg);
@@ -1832,8 +1832,8 @@ class _AmazingIconBulkBg {
   /// Icon data for monitorBg icon.
   static const IconData monitorBg = IconData(0xf285, fontFamily: _kFontFam, fontPackage: _kFontPkg);
 
-  /// Icon data for monitorMobbileBg icon.
-  static const IconData monitorMobbileBg = IconData(0xf287, fontFamily: _kFontFam, fontPackage: _kFontPkg);
+  /// Icon data for monitorMobileBg icon.
+  static const IconData monitorMobileBg = IconData(0xf287, fontFamily: _kFontFam, fontPackage: _kFontPkg);
 
   /// Icon data for monitorRecorderBg icon.
   static const IconData monitorRecorderBg = IconData(0xf286, fontFamily: _kFontFam, fontPackage: _kFontPkg);
@@ -1880,8 +1880,8 @@ class _AmazingIconBulkBg {
   /// Icon data for musicLibrary2Bg icon.
   static const IconData musicLibrary2Bg = IconData(0xf278, fontFamily: _kFontFam, fontPackage: _kFontPkg);
 
-  /// Icon data for musicnoteBg icon.
-  static const IconData musicnoteBg = IconData(0xf270, fontFamily: _kFontFam, fontPackage: _kFontPkg);
+  /// Icon data for musicNoteBg icon.
+  static const IconData musicNoteBg = IconData(0xf270, fontFamily: _kFontFam, fontPackage: _kFontPkg);
 
   /// Icon data for musicPlayBg icon.
   static const IconData musicPlayBg = IconData(0xf277, fontFamily: _kFontFam, fontPackage: _kFontPkg);
@@ -2039,8 +2039,8 @@ class _AmazingIconBulkBg {
   /// Icon data for petBg icon.
   static const IconData petBg = IconData(0xf242, fontFamily: _kFontFam, fontPackage: _kFontPkg);
 
-  /// Icon data for pharagraphspacingBg icon.
-  static const IconData pharagraphspacingBg = IconData(0xf241, fontFamily: _kFontFam, fontPackage: _kFontPkg);
+  /// Icon data for paragraphSpacingBg icon.
+  static const IconData paragraphSpacingBg = IconData(0xf241, fontFamily: _kFontFam, fontPackage: _kFontPkg);
 
   /// Icon data for photoshopBg icon.
   static const IconData photoshopBg = IconData(0xf240, fontFamily: _kFontFam, fontPackage: _kFontPkg);
@@ -2057,8 +2057,8 @@ class _AmazingIconBulkBg {
   /// Icon data for playCircleBg icon.
   static const IconData playCircleBg = IconData(0xf23d, fontFamily: _kFontFam, fontPackage: _kFontPkg);
 
-  /// Icon data for playCricleBg icon.
-  static const IconData playCricleBg = IconData(0xf23c, fontFamily: _kFontFam, fontPackage: _kFontPkg);
+  /// Icon data for playCircle2Bg icon.
+  static const IconData playCircle2Bg = IconData(0xf23c, fontFamily: _kFontFam, fontPackage: _kFontPkg);
 
   /// Icon data for playRemoveBg icon.
   static const IconData playRemoveBg = IconData(0xf23b, fontFamily: _kFontFam, fontPackage: _kFontPkg);
@@ -2072,8 +2072,8 @@ class _AmazingIconBulkBg {
   /// Icon data for polyswarmBg icon.
   static const IconData polyswarmBg = IconData(0xf237, fontFamily: _kFontFam, fontPackage: _kFontPkg);
 
-  /// Icon data for presentionChartBg icon.
-  static const IconData presentionChartBg = IconData(0xf236, fontFamily: _kFontFam, fontPackage: _kFontPkg);
+  /// Icon data for presentationChartBg icon.
+  static const IconData presentationChartBg = IconData(0xf236, fontFamily: _kFontFam, fontPackage: _kFontPkg);
 
   /// Icon data for previousBg icon.
   static const IconData previousBg = IconData(0xf235, fontFamily: _kFontFam, fontPackage: _kFontPkg);
@@ -2243,11 +2243,11 @@ class _AmazingIconBulkBg {
   /// Icon data for repeatCircleBg icon.
   static const IconData repeatCircleBg = IconData(0xf1ff, fontFamily: _kFontFam, fontPackage: _kFontPkg);
 
-  /// Icon data for repeateMusicBg icon.
-  static const IconData repeateMusicBg = IconData(0xf1fd, fontFamily: _kFontFam, fontPackage: _kFontPkg);
+  /// Icon data for repeatMusicBg icon.
+  static const IconData repeatMusicBg = IconData(0xf1fd, fontFamily: _kFontFam, fontPackage: _kFontPkg);
 
-  /// Icon data for repeateOneBg icon.
-  static const IconData repeateOneBg = IconData(0xf1fc, fontFamily: _kFontFam, fontPackage: _kFontPkg);
+  /// Icon data for repeatOneBg icon.
+  static const IconData repeatOneBg = IconData(0xf1fc, fontFamily: _kFontFam, fontPackage: _kFontPkg);
 
   /// Icon data for reserveBg icon.
   static const IconData reserveBg = IconData(0xf1fb, fontFamily: _kFontFam, fontPackage: _kFontPkg);
@@ -2387,8 +2387,8 @@ class _AmazingIconBulkBg {
   /// Icon data for send2Bg icon.
   static const IconData send2Bg = IconData(0xf1cf, fontFamily: _kFontFam, fontPackage: _kFontPkg);
 
-  /// Icon data for sendSqaure2Bg icon.
-  static const IconData sendSqaure2Bg = IconData(0xf1ce, fontFamily: _kFontFam, fontPackage: _kFontPkg);
+  /// Icon data for sendSquare2Bg icon.
+  static const IconData sendSquare2Bg = IconData(0xf1ce, fontFamily: _kFontFam, fontPackage: _kFontPkg);
 
   /// Icon data for sendSquareBg icon.
   static const IconData sendSquareBg = IconData(0xf1cd, fontFamily: _kFontFam, fontPackage: _kFontPkg);
@@ -3363,7 +3363,7 @@ class _AmazingIconBulkBg {
     'filterSearchBg': filterSearchBg,
     'filterSquareBg': filterSquareBg,
     'filterTickBg': filterTickBg,
-    'fingerCricleBg': fingerCricleBg,
+    'fingerCircleBg': fingerCircleBg,
     'fingerScanBg': fingerScanBg,
     'firstlineBg': firstlineBg,
     'flagBg': flagBg,
@@ -3435,7 +3435,7 @@ class _AmazingIconBulkBg {
     'gridEditBg': gridEditBg,
     'gridEraserBg': gridEraserBg,
     'gridLockBg': gridLockBg,
-    'happyemojiBg': happyemojiBg,
+    'happyEmojiBg': happyEmojiBg,
     'harmonyBg': harmonyBg,
     'hashtagBg': hashtagBg,
     'hashtag1Bg': hashtag1Bg,
@@ -3587,9 +3587,9 @@ class _AmazingIconBulkBg {
     'microphoneSlash1Bg': microphoneSlash1Bg,
     'microscopeBg': microscopeBg,
     'milkBg': milkBg,
-    'miniMusicSqaureBg': miniMusicSqaureBg,
+    'miniMusicSquareBg': miniMusicSquareBg,
     'minusBg': minusBg,
-    'minusCirlceBg': minusCirlceBg,
+    'minusCircleBg': minusCircleBg,
     'minusSquareBg': minusSquareBg,
     'mirrorBg': mirrorBg,
     'mirroringScreenBg': mirroringScreenBg,
@@ -3610,7 +3610,7 @@ class _AmazingIconBulkBg {
     'moneyTimeBg': moneyTimeBg,
     'moneysBg': moneysBg,
     'monitorBg': monitorBg,
-    'monitorMobbileBg': monitorMobbileBg,
+    'monitorMobileBg': monitorMobileBg,
     'monitorRecorderBg': monitorRecorderBg,
     'moonBg': moonBg,
     'moreBg': moreBg,
@@ -3632,7 +3632,7 @@ class _AmazingIconBulkBg {
     'musicSquareAddBg': musicSquareAddBg,
     'musicSquareRemoveBg': musicSquareRemoveBg,
     'musicSquareSearchBg': musicSquareSearchBg,
-    'musicnoteBg': musicnoteBg,
+    'musicNoteBg': musicNoteBg,
     'nebulasBg': nebulasBg,
     'nemBg': nemBg,
     'nexoBg': nexoBg,
@@ -3679,18 +3679,18 @@ class _AmazingIconBulkBg {
     'percentageSquareBg': percentageSquareBg,
     'personalcardBg': personalcardBg,
     'petBg': petBg,
-    'pharagraphspacingBg': pharagraphspacingBg,
+    'paragraphSpacingBg': paragraphSpacingBg,
     'photoshopBg': photoshopBg,
     'pictureFrameBg': pictureFrameBg,
     'playBg': playBg,
     'playAddBg': playAddBg,
     'playCircleBg': playCircleBg,
-    'playCricleBg': playCricleBg,
+    'playCircle2Bg': playCircle2Bg,
     'playRemoveBg': playRemoveBg,
     'polkadotBg': polkadotBg,
     'polygonBg': polygonBg,
     'polyswarmBg': polyswarmBg,
-    'presentionChartBg': presentionChartBg,
+    'presentationChartBg': presentationChartBg,
     'previousBg': previousBg,
     'printerBg': printerBg,
     'printerSlashBg': printerSlashBg,
@@ -3747,8 +3747,8 @@ class _AmazingIconBulkBg {
     'refreshSquare2Bg': refreshSquare2Bg,
     'repeatBg': repeatBg,
     'repeatCircleBg': repeatCircleBg,
-    'repeateMusicBg': repeateMusicBg,
-    'repeateOneBg': repeateOneBg,
+    'repeatMusicBg': repeatMusicBg,
+    'repeatOneBg': repeatOneBg,
     'reserveBg': reserveBg,
     'rotate3dBg': rotate3dBg,
     'rotateLeftBg': rotateLeftBg,
@@ -3795,7 +3795,7 @@ class _AmazingIconBulkBg {
     'sendBg': sendBg,
     'send1Bg': send1Bg,
     'send2Bg': send2Bg,
-    'sendSqaure2Bg': sendSqaure2Bg,
+    'sendSquare2Bg': sendSquare2Bg,
     'sendSquareBg': sendSquareBg,
     'settingBg': settingBg,
     'setting2Bg': setting2Bg,

--- a/lib/src/components/amazing_icon_bulk_fg.dart
+++ b/lib/src/components/amazing_icon_bulk_fg.dart
@@ -1091,8 +1091,8 @@ class _AmazingIconBulkFg {
   /// Icon data for filterTickFg icon.
   static const IconData filterTickFg = IconData(0xf37f, fontFamily: _kFontFam, fontPackage: _kFontPkg);
 
-  /// Icon data for fingerCricleFg icon.
-  static const IconData fingerCricleFg = IconData(0xf37d, fontFamily: _kFontFam, fontPackage: _kFontPkg);
+  /// Icon data for fingerCircleFg icon.
+  static const IconData fingerCircleFg = IconData(0xf37d, fontFamily: _kFontFam, fontPackage: _kFontPkg);
 
   /// Icon data for fingerScanFg icon.
   static const IconData fingerScanFg = IconData(0xf37c, fontFamily: _kFontFam, fontPackage: _kFontPkg);
@@ -1307,8 +1307,8 @@ class _AmazingIconBulkFg {
   /// Icon data for gridLockFg icon.
   static const IconData gridLockFg = IconData(0xf336, fontFamily: _kFontFam, fontPackage: _kFontPkg);
 
-  /// Icon data for happyemojiFg icon.
-  static const IconData happyemojiFg = IconData(0xf335, fontFamily: _kFontFam, fontPackage: _kFontPkg);
+  /// Icon data for happyEmojiFg icon.
+  static const IconData happyEmojiFg = IconData(0xf335, fontFamily: _kFontFam, fontPackage: _kFontPkg);
 
   /// Icon data for harmonyFg icon.
   static const IconData harmonyFg = IconData(0xf334, fontFamily: _kFontFam, fontPackage: _kFontPkg);
@@ -1763,14 +1763,14 @@ class _AmazingIconBulkFg {
   /// Icon data for milkFg icon.
   static const IconData milkFg = IconData(0xf29e, fontFamily: _kFontFam, fontPackage: _kFontPkg);
 
-  /// Icon data for miniMusicSqaureFg icon.
-  static const IconData miniMusicSqaureFg = IconData(0xf29d, fontFamily: _kFontFam, fontPackage: _kFontPkg);
+  /// Icon data for miniMusicSquareFg icon.
+  static const IconData miniMusicSquareFg = IconData(0xf29d, fontFamily: _kFontFam, fontPackage: _kFontPkg);
 
   /// Icon data for minusFg icon.
   static const IconData minusFg = IconData(0xf29a, fontFamily: _kFontFam, fontPackage: _kFontPkg);
 
-  /// Icon data for minusCirlceFg icon.
-  static const IconData minusCirlceFg = IconData(0xf29c, fontFamily: _kFontFam, fontPackage: _kFontPkg);
+  /// Icon data for minusCircleFg icon.
+  static const IconData minusCircleFg = IconData(0xf29c, fontFamily: _kFontFam, fontPackage: _kFontPkg);
 
   /// Icon data for minusSquareFg icon.
   static const IconData minusSquareFg = IconData(0xf29b, fontFamily: _kFontFam, fontPackage: _kFontPkg);
@@ -1832,8 +1832,8 @@ class _AmazingIconBulkFg {
   /// Icon data for monitorFg icon.
   static const IconData monitorFg = IconData(0xf285, fontFamily: _kFontFam, fontPackage: _kFontPkg);
 
-  /// Icon data for monitorMobbileFg icon.
-  static const IconData monitorMobbileFg = IconData(0xf287, fontFamily: _kFontFam, fontPackage: _kFontPkg);
+  /// Icon data for monitorMobileFg icon.
+  static const IconData monitorMobileFg = IconData(0xf287, fontFamily: _kFontFam, fontPackage: _kFontPkg);
 
   /// Icon data for monitorRecorderFg icon.
   static const IconData monitorRecorderFg = IconData(0xf286, fontFamily: _kFontFam, fontPackage: _kFontPkg);
@@ -1880,8 +1880,8 @@ class _AmazingIconBulkFg {
   /// Icon data for musicLibrary2Fg icon.
   static const IconData musicLibrary2Fg = IconData(0xf278, fontFamily: _kFontFam, fontPackage: _kFontPkg);
 
-  /// Icon data for musicnoteFg icon.
-  static const IconData musicnoteFg = IconData(0xf270, fontFamily: _kFontFam, fontPackage: _kFontPkg);
+  /// Icon data for musicNoteFg icon.
+  static const IconData musicNoteFg = IconData(0xf270, fontFamily: _kFontFam, fontPackage: _kFontPkg);
 
   /// Icon data for musicPlayFg icon.
   static const IconData musicPlayFg = IconData(0xf277, fontFamily: _kFontFam, fontPackage: _kFontPkg);
@@ -2039,8 +2039,8 @@ class _AmazingIconBulkFg {
   /// Icon data for petFg icon.
   static const IconData petFg = IconData(0xf242, fontFamily: _kFontFam, fontPackage: _kFontPkg);
 
-  /// Icon data for pharagraphspacingFg icon.
-  static const IconData pharagraphspacingFg = IconData(0xf241, fontFamily: _kFontFam, fontPackage: _kFontPkg);
+  /// Icon data for paragraphSpacingFg icon.
+  static const IconData paragraphSpacingFg = IconData(0xf241, fontFamily: _kFontFam, fontPackage: _kFontPkg);
 
   /// Icon data for photoshopFg icon.
   static const IconData photoshopFg = IconData(0xf240, fontFamily: _kFontFam, fontPackage: _kFontPkg);
@@ -2057,8 +2057,8 @@ class _AmazingIconBulkFg {
   /// Icon data for playCircleFg icon.
   static const IconData playCircleFg = IconData(0xf23d, fontFamily: _kFontFam, fontPackage: _kFontPkg);
 
-  /// Icon data for playCricleFg icon.
-  static const IconData playCricleFg = IconData(0xf23c, fontFamily: _kFontFam, fontPackage: _kFontPkg);
+  /// Icon data for playCircle2Fg icon.
+  static const IconData playCircle2Fg = IconData(0xf23c, fontFamily: _kFontFam, fontPackage: _kFontPkg);
 
   /// Icon data for playRemoveFg icon.
   static const IconData playRemoveFg = IconData(0xf23b, fontFamily: _kFontFam, fontPackage: _kFontPkg);
@@ -2072,8 +2072,8 @@ class _AmazingIconBulkFg {
   /// Icon data for polyswarmFg icon.
   static const IconData polyswarmFg = IconData(0xf237, fontFamily: _kFontFam, fontPackage: _kFontPkg);
 
-  /// Icon data for presentionChartFg icon.
-  static const IconData presentionChartFg = IconData(0xf236, fontFamily: _kFontFam, fontPackage: _kFontPkg);
+  /// Icon data for presentationChartFg icon.
+  static const IconData presentationChartFg = IconData(0xf236, fontFamily: _kFontFam, fontPackage: _kFontPkg);
 
   /// Icon data for previousFg icon.
   static const IconData previousFg = IconData(0xf235, fontFamily: _kFontFam, fontPackage: _kFontPkg);
@@ -2243,11 +2243,11 @@ class _AmazingIconBulkFg {
   /// Icon data for repeatCircleFg icon.
   static const IconData repeatCircleFg = IconData(0xf1ff, fontFamily: _kFontFam, fontPackage: _kFontPkg);
 
-  /// Icon data for repeateMusicFg icon.
-  static const IconData repeateMusicFg = IconData(0xf1fd, fontFamily: _kFontFam, fontPackage: _kFontPkg);
+  /// Icon data for repeatMusicFg icon.
+  static const IconData repeatMusicFg = IconData(0xf1fd, fontFamily: _kFontFam, fontPackage: _kFontPkg);
 
-  /// Icon data for repeateOneFg icon.
-  static const IconData repeateOneFg = IconData(0xf1fc, fontFamily: _kFontFam, fontPackage: _kFontPkg);
+  /// Icon data for repeatOneFg icon.
+  static const IconData repeatOneFg = IconData(0xf1fc, fontFamily: _kFontFam, fontPackage: _kFontPkg);
 
   /// Icon data for reserveFg icon.
   static const IconData reserveFg = IconData(0xf1fb, fontFamily: _kFontFam, fontPackage: _kFontPkg);
@@ -2387,8 +2387,8 @@ class _AmazingIconBulkFg {
   /// Icon data for send2Fg icon.
   static const IconData send2Fg = IconData(0xf1cf, fontFamily: _kFontFam, fontPackage: _kFontPkg);
 
-  /// Icon data for sendSqaure2Fg icon.
-  static const IconData sendSqaure2Fg = IconData(0xf1ce, fontFamily: _kFontFam, fontPackage: _kFontPkg);
+  /// Icon data for sendSquare2Fg icon.
+  static const IconData sendSquare2Fg = IconData(0xf1ce, fontFamily: _kFontFam, fontPackage: _kFontPkg);
 
   /// Icon data for sendSquareFg icon.
   static const IconData sendSquareFg = IconData(0xf1cd, fontFamily: _kFontFam, fontPackage: _kFontPkg);
@@ -3363,7 +3363,7 @@ class _AmazingIconBulkFg {
     'filterSearchFg': filterSearchFg,
     'filterSquareFg': filterSquareFg,
     'filterTickFg': filterTickFg,
-    'fingerCricleFg': fingerCricleFg,
+    'fingerCircleFg': fingerCircleFg,
     'fingerScanFg': fingerScanFg,
     'firstlineFg': firstlineFg,
     'flagFg': flagFg,
@@ -3435,7 +3435,7 @@ class _AmazingIconBulkFg {
     'gridEditFg': gridEditFg,
     'gridEraserFg': gridEraserFg,
     'gridLockFg': gridLockFg,
-    'happyemojiFg': happyemojiFg,
+    'happyEmojiFg': happyEmojiFg,
     'harmonyFg': harmonyFg,
     'hashtagFg': hashtagFg,
     'hashtag1Fg': hashtag1Fg,
@@ -3587,9 +3587,9 @@ class _AmazingIconBulkFg {
     'microphoneSlash1Fg': microphoneSlash1Fg,
     'microscopeFg': microscopeFg,
     'milkFg': milkFg,
-    'miniMusicSqaureFg': miniMusicSqaureFg,
+    'miniMusicSquareFg': miniMusicSquareFg,
     'minusFg': minusFg,
-    'minusCirlceFg': minusCirlceFg,
+    'minusCircleFg': minusCircleFg,
     'minusSquareFg': minusSquareFg,
     'mirrorFg': mirrorFg,
     'mirroringScreenFg': mirroringScreenFg,
@@ -3610,7 +3610,7 @@ class _AmazingIconBulkFg {
     'moneyTimeFg': moneyTimeFg,
     'moneysFg': moneysFg,
     'monitorFg': monitorFg,
-    'monitorMobbileFg': monitorMobbileFg,
+    'monitorMobileFg': monitorMobileFg,
     'monitorRecorderFg': monitorRecorderFg,
     'moonFg': moonFg,
     'moreFg': moreFg,
@@ -3632,7 +3632,7 @@ class _AmazingIconBulkFg {
     'musicSquareAddFg': musicSquareAddFg,
     'musicSquareRemoveFg': musicSquareRemoveFg,
     'musicSquareSearchFg': musicSquareSearchFg,
-    'musicnoteFg': musicnoteFg,
+    'musicNoteFg': musicNoteFg,
     'nebulasFg': nebulasFg,
     'nemFg': nemFg,
     'nexoFg': nexoFg,
@@ -3679,18 +3679,18 @@ class _AmazingIconBulkFg {
     'percentageSquareFg': percentageSquareFg,
     'personalcardFg': personalcardFg,
     'petFg': petFg,
-    'pharagraphspacingFg': pharagraphspacingFg,
+    'paragraphSpacingFg': paragraphSpacingFg,
     'photoshopFg': photoshopFg,
     'pictureFrameFg': pictureFrameFg,
     'playFg': playFg,
     'playAddFg': playAddFg,
     'playCircleFg': playCircleFg,
-    'playCricleFg': playCricleFg,
+    'playCircle2Fg': playCircle2Fg,
     'playRemoveFg': playRemoveFg,
     'polkadotFg': polkadotFg,
     'polygonFg': polygonFg,
     'polyswarmFg': polyswarmFg,
-    'presentionChartFg': presentionChartFg,
+    'presentationChartFg': presentationChartFg,
     'previousFg': previousFg,
     'printerFg': printerFg,
     'printerSlashFg': printerSlashFg,
@@ -3747,8 +3747,8 @@ class _AmazingIconBulkFg {
     'refreshSquare2Fg': refreshSquare2Fg,
     'repeatFg': repeatFg,
     'repeatCircleFg': repeatCircleFg,
-    'repeateMusicFg': repeateMusicFg,
-    'repeateOneFg': repeateOneFg,
+    'repeatMusicFg': repeatMusicFg,
+    'repeatOneFg': repeatOneFg,
     'reserveFg': reserveFg,
     'rotate3dFg': rotate3dFg,
     'rotateLeftFg': rotateLeftFg,
@@ -3795,7 +3795,7 @@ class _AmazingIconBulkFg {
     'sendFg': sendFg,
     'send1Fg': send1Fg,
     'send2Fg': send2Fg,
-    'sendSqaure2Fg': sendSqaure2Fg,
+    'sendSquare2Fg': sendSquare2Fg,
     'sendSquareFg': sendSquareFg,
     'settingFg': settingFg,
     'setting2Fg': setting2Fg,

--- a/lib/src/components/amazing_icon_twotone_bg.dart
+++ b/lib/src/components/amazing_icon_twotone_bg.dart
@@ -1028,8 +1028,8 @@ class _AmazingIconTwotoneBg {
   /// Icon data for filterTickBg icon.
   static const IconData filterTickBg = IconData(0xf368, fontFamily: _kFontFam, fontPackage: _kFontPkg);
 
-  /// Icon data for fingerCricleBg icon.
-  static const IconData fingerCricleBg = IconData(0xf366, fontFamily: _kFontFam, fontPackage: _kFontPkg);
+  /// Icon data for fingerCircleBg icon.
+  static const IconData fingerCircleBg = IconData(0xf366, fontFamily: _kFontFam, fontPackage: _kFontPkg);
 
   /// Icon data for fingerScanBg icon.
   static const IconData fingerScanBg = IconData(0xf365, fontFamily: _kFontFam, fontPackage: _kFontPkg);
@@ -1232,8 +1232,8 @@ class _AmazingIconTwotoneBg {
   /// Icon data for gridLockBg icon.
   static const IconData gridLockBg = IconData(0xf323, fontFamily: _kFontFam, fontPackage: _kFontPkg);
 
-  /// Icon data for happyemojiBg icon.
-  static const IconData happyemojiBg = IconData(0xf322, fontFamily: _kFontFam, fontPackage: _kFontPkg);
+  /// Icon data for happyEmojiBg icon.
+  static const IconData happyEmojiBg = IconData(0xf322, fontFamily: _kFontFam, fontPackage: _kFontPkg);
 
   /// Icon data for harmonyBg icon.
   static const IconData harmonyBg = IconData(0xf321, fontFamily: _kFontFam, fontPackage: _kFontPkg);
@@ -1682,11 +1682,11 @@ class _AmazingIconTwotoneBg {
   /// Icon data for milkBg icon.
   static const IconData milkBg = IconData(0xf28d, fontFamily: _kFontFam, fontPackage: _kFontPkg);
 
-  /// Icon data for miniMusicSqaureBg icon.
-  static const IconData miniMusicSqaureBg = IconData(0xf28c, fontFamily: _kFontFam, fontPackage: _kFontPkg);
+  /// Icon data for miniMusicSquareBg icon.
+  static const IconData miniMusicSquareBg = IconData(0xf28c, fontFamily: _kFontFam, fontPackage: _kFontPkg);
 
-  /// Icon data for minusCirlceBg icon.
-  static const IconData minusCirlceBg = IconData(0xf28b, fontFamily: _kFontFam, fontPackage: _kFontPkg);
+  /// Icon data for minusCircleBg icon.
+  static const IconData minusCircleBg = IconData(0xf28b, fontFamily: _kFontFam, fontPackage: _kFontPkg);
 
   /// Icon data for minusSquareBg icon.
   static const IconData minusSquareBg = IconData(0xf28a, fontFamily: _kFontFam, fontPackage: _kFontPkg);
@@ -1748,8 +1748,8 @@ class _AmazingIconTwotoneBg {
   /// Icon data for monitorBg icon.
   static const IconData monitorBg = IconData(0xf275, fontFamily: _kFontFam, fontPackage: _kFontPkg);
 
-  /// Icon data for monitorMobbileBg icon.
-  static const IconData monitorMobbileBg = IconData(0xf277, fontFamily: _kFontFam, fontPackage: _kFontPkg);
+  /// Icon data for monitorMobileBg icon.
+  static const IconData monitorMobileBg = IconData(0xf277, fontFamily: _kFontFam, fontPackage: _kFontPkg);
 
   /// Icon data for monitorRecorderBg icon.
   static const IconData monitorRecorderBg = IconData(0xf276, fontFamily: _kFontFam, fontPackage: _kFontPkg);
@@ -1793,8 +1793,8 @@ class _AmazingIconTwotoneBg {
   /// Icon data for musicLibrary2Bg icon.
   static const IconData musicLibrary2Bg = IconData(0xf269, fontFamily: _kFontFam, fontPackage: _kFontPkg);
 
-  /// Icon data for musicnoteBg icon.
-  static const IconData musicnoteBg = IconData(0xf261, fontFamily: _kFontFam, fontPackage: _kFontPkg);
+  /// Icon data for musicNoteBg icon.
+  static const IconData musicNoteBg = IconData(0xf261, fontFamily: _kFontFam, fontPackage: _kFontPkg);
 
   /// Icon data for musicPlayBg icon.
   static const IconData musicPlayBg = IconData(0xf268, fontFamily: _kFontFam, fontPackage: _kFontPkg);
@@ -1946,8 +1946,8 @@ class _AmazingIconTwotoneBg {
   /// Icon data for petBg icon.
   static const IconData petBg = IconData(0xf235, fontFamily: _kFontFam, fontPackage: _kFontPkg);
 
-  /// Icon data for pharagraphspacingBg icon.
-  static const IconData pharagraphspacingBg = IconData(0xf234, fontFamily: _kFontFam, fontPackage: _kFontPkg);
+  /// Icon data for paragraphSpacingBg icon.
+  static const IconData paragraphSpacingBg = IconData(0xf234, fontFamily: _kFontFam, fontPackage: _kFontPkg);
 
   /// Icon data for photoshopBg icon.
   static const IconData photoshopBg = IconData(0xf233, fontFamily: _kFontFam, fontPackage: _kFontPkg);
@@ -1961,8 +1961,8 @@ class _AmazingIconTwotoneBg {
   /// Icon data for playCircleBg icon.
   static const IconData playCircleBg = IconData(0xf230, fontFamily: _kFontFam, fontPackage: _kFontPkg);
 
-  /// Icon data for playCricleBg icon.
-  static const IconData playCricleBg = IconData(0xf22f, fontFamily: _kFontFam, fontPackage: _kFontPkg);
+  /// Icon data for playCircle2Bg icon.
+  static const IconData playCircle2Bg = IconData(0xf22f, fontFamily: _kFontFam, fontPackage: _kFontPkg);
 
   /// Icon data for playRemoveBg icon.
   static const IconData playRemoveBg = IconData(0xf22e, fontFamily: _kFontFam, fontPackage: _kFontPkg);
@@ -1976,8 +1976,8 @@ class _AmazingIconTwotoneBg {
   /// Icon data for polyswarmBg icon.
   static const IconData polyswarmBg = IconData(0xf22b, fontFamily: _kFontFam, fontPackage: _kFontPkg);
 
-  /// Icon data for presentionChartBg icon.
-  static const IconData presentionChartBg = IconData(0xf22a, fontFamily: _kFontFam, fontPackage: _kFontPkg);
+  /// Icon data for presentationChartBg icon.
+  static const IconData presentationChartBg = IconData(0xf22a, fontFamily: _kFontFam, fontPackage: _kFontPkg);
 
   /// Icon data for previousBg icon.
   static const IconData previousBg = IconData(0xf229, fontFamily: _kFontFam, fontPackage: _kFontPkg);
@@ -2141,11 +2141,11 @@ class _AmazingIconTwotoneBg {
   /// Icon data for repeatCircleBg icon.
   static const IconData repeatCircleBg = IconData(0xf1f5, fontFamily: _kFontFam, fontPackage: _kFontPkg);
 
-  /// Icon data for repeateMusicBg icon.
-  static const IconData repeateMusicBg = IconData(0xf1f3, fontFamily: _kFontFam, fontPackage: _kFontPkg);
+  /// Icon data for repeatMusicBg icon.
+  static const IconData repeatMusicBg = IconData(0xf1f3, fontFamily: _kFontFam, fontPackage: _kFontPkg);
 
-  /// Icon data for repeateOneBg icon.
-  static const IconData repeateOneBg = IconData(0xf1f2, fontFamily: _kFontFam, fontPackage: _kFontPkg);
+  /// Icon data for repeatOneBg icon.
+  static const IconData repeatOneBg = IconData(0xf1f2, fontFamily: _kFontFam, fontPackage: _kFontPkg);
 
   /// Icon data for reserveBg icon.
   static const IconData reserveBg = IconData(0xf1f1, fontFamily: _kFontFam, fontPackage: _kFontPkg);
@@ -2285,8 +2285,8 @@ class _AmazingIconTwotoneBg {
   /// Icon data for send2Bg icon.
   static const IconData send2Bg = IconData(0xf1c5, fontFamily: _kFontFam, fontPackage: _kFontPkg);
 
-  /// Icon data for sendSqaure2Bg icon.
-  static const IconData sendSqaure2Bg = IconData(0xf1c4, fontFamily: _kFontFam, fontPackage: _kFontPkg);
+  /// Icon data for sendSquare2Bg icon.
+  static const IconData sendSquare2Bg = IconData(0xf1c4, fontFamily: _kFontFam, fontPackage: _kFontPkg);
 
   /// Icon data for sendSquareBg icon.
   static const IconData sendSquareBg = IconData(0xf1c3, fontFamily: _kFontFam, fontPackage: _kFontPkg);
@@ -3210,7 +3210,7 @@ class _AmazingIconTwotoneBg {
     'filterSearchBg': filterSearchBg,
     'filterSquareBg': filterSquareBg,
     'filterTickBg': filterTickBg,
-    'fingerCricleBg': fingerCricleBg,
+    'fingerCircleBg': fingerCircleBg,
     'fingerScanBg': fingerScanBg,
     'firstlineBg': firstlineBg,
     'flagBg': flagBg,
@@ -3278,7 +3278,7 @@ class _AmazingIconTwotoneBg {
     'gridEditBg': gridEditBg,
     'gridEraserBg': gridEraserBg,
     'gridLockBg': gridLockBg,
-    'happyemojiBg': happyemojiBg,
+    'happyEmojiBg': happyEmojiBg,
     'harmonyBg': harmonyBg,
     'hashtagBg': hashtagBg,
     'hashtag1Bg': hashtag1Bg,
@@ -3428,8 +3428,8 @@ class _AmazingIconTwotoneBg {
     'microphoneSlash1Bg': microphoneSlash1Bg,
     'microscopeBg': microscopeBg,
     'milkBg': milkBg,
-    'miniMusicSqaureBg': miniMusicSqaureBg,
-    'minusCirlceBg': minusCirlceBg,
+    'miniMusicSquareBg': miniMusicSquareBg,
+    'minusCircleBg': minusCircleBg,
     'minusSquareBg': minusSquareBg,
     'mirrorBg': mirrorBg,
     'mirroringScreenBg': mirroringScreenBg,
@@ -3450,7 +3450,7 @@ class _AmazingIconTwotoneBg {
     'moneyTimeBg': moneyTimeBg,
     'moneysBg': moneysBg,
     'monitorBg': monitorBg,
-    'monitorMobbileBg': monitorMobbileBg,
+    'monitorMobileBg': monitorMobileBg,
     'monitorRecorderBg': monitorRecorderBg,
     'moreBg': moreBg,
     'more2Bg': more2Bg,
@@ -3471,7 +3471,7 @@ class _AmazingIconTwotoneBg {
     'musicSquareAddBg': musicSquareAddBg,
     'musicSquareRemoveBg': musicSquareRemoveBg,
     'musicSquareSearchBg': musicSquareSearchBg,
-    'musicnoteBg': musicnoteBg,
+    'musicNoteBg': musicNoteBg,
     'nebulasBg': nebulasBg,
     'nemBg': nemBg,
     'nexoBg': nexoBg,
@@ -3516,17 +3516,17 @@ class _AmazingIconTwotoneBg {
     'percentageSquareBg': percentageSquareBg,
     'personalcardBg': personalcardBg,
     'petBg': petBg,
-    'pharagraphspacingBg': pharagraphspacingBg,
+    'paragraphSpacingBg': paragraphSpacingBg,
     'photoshopBg': photoshopBg,
     'pictureFrameBg': pictureFrameBg,
     'playAddBg': playAddBg,
     'playCircleBg': playCircleBg,
-    'playCricleBg': playCricleBg,
+    'playCircle2Bg': playCircle2Bg,
     'playRemoveBg': playRemoveBg,
     'polkadotBg': polkadotBg,
     'polygonBg': polygonBg,
     'polyswarmBg': polyswarmBg,
-    'presentionChartBg': presentionChartBg,
+    'presentationChartBg': presentationChartBg,
     'previousBg': previousBg,
     'printerBg': printerBg,
     'printerSlashBg': printerSlashBg,
@@ -3581,8 +3581,8 @@ class _AmazingIconTwotoneBg {
     'refreshSquare2Bg': refreshSquare2Bg,
     'repeatBg': repeatBg,
     'repeatCircleBg': repeatCircleBg,
-    'repeateMusicBg': repeateMusicBg,
-    'repeateOneBg': repeateOneBg,
+    'repeatMusicBg': repeatMusicBg,
+    'repeatOneBg': repeatOneBg,
     'reserveBg': reserveBg,
     'rotate3dBg': rotate3dBg,
     'rotateLeftBg': rotateLeftBg,
@@ -3629,7 +3629,7 @@ class _AmazingIconTwotoneBg {
     'sendBg': sendBg,
     'send1Bg': send1Bg,
     'send2Bg': send2Bg,
-    'sendSqaure2Bg': sendSqaure2Bg,
+    'sendSquare2Bg': sendSquare2Bg,
     'sendSquareBg': sendSquareBg,
     'settingBg': settingBg,
     'setting2Bg': setting2Bg,

--- a/lib/src/components/amazing_icon_twotone_fg.dart
+++ b/lib/src/components/amazing_icon_twotone_fg.dart
@@ -1028,8 +1028,8 @@ class _AmazingIconTwotoneFg {
   /// Icon data for filterTickFg icon.
   static const IconData filterTickFg = IconData(0xf368, fontFamily: _kFontFam, fontPackage: _kFontPkg);
 
-  /// Icon data for fingerCricleFg icon.
-  static const IconData fingerCricleFg = IconData(0xf366, fontFamily: _kFontFam, fontPackage: _kFontPkg);
+  /// Icon data for fingerCircleFg icon.
+  static const IconData fingerCircleFg = IconData(0xf366, fontFamily: _kFontFam, fontPackage: _kFontPkg);
 
   /// Icon data for fingerScanFg icon.
   static const IconData fingerScanFg = IconData(0xf365, fontFamily: _kFontFam, fontPackage: _kFontPkg);
@@ -1232,8 +1232,8 @@ class _AmazingIconTwotoneFg {
   /// Icon data for gridLockFg icon.
   static const IconData gridLockFg = IconData(0xf323, fontFamily: _kFontFam, fontPackage: _kFontPkg);
 
-  /// Icon data for happyemojiFg icon.
-  static const IconData happyemojiFg = IconData(0xf322, fontFamily: _kFontFam, fontPackage: _kFontPkg);
+  /// Icon data for happyEmojiFg icon.
+  static const IconData happyEmojiFg = IconData(0xf322, fontFamily: _kFontFam, fontPackage: _kFontPkg);
 
   /// Icon data for harmonyFg icon.
   static const IconData harmonyFg = IconData(0xf321, fontFamily: _kFontFam, fontPackage: _kFontPkg);
@@ -1682,11 +1682,11 @@ class _AmazingIconTwotoneFg {
   /// Icon data for milkFg icon.
   static const IconData milkFg = IconData(0xf28d, fontFamily: _kFontFam, fontPackage: _kFontPkg);
 
-  /// Icon data for miniMusicSqaureFg icon.
-  static const IconData miniMusicSqaureFg = IconData(0xf28c, fontFamily: _kFontFam, fontPackage: _kFontPkg);
+  /// Icon data for miniMusicSquareFg icon.
+  static const IconData miniMusicSquareFg = IconData(0xf28c, fontFamily: _kFontFam, fontPackage: _kFontPkg);
 
-  /// Icon data for minusCirlceFg icon.
-  static const IconData minusCirlceFg = IconData(0xf28b, fontFamily: _kFontFam, fontPackage: _kFontPkg);
+  /// Icon data for minusCircleFg icon.
+  static const IconData minusCircleFg = IconData(0xf28b, fontFamily: _kFontFam, fontPackage: _kFontPkg);
 
   /// Icon data for minusSquareFg icon.
   static const IconData minusSquareFg = IconData(0xf28a, fontFamily: _kFontFam, fontPackage: _kFontPkg);
@@ -1748,8 +1748,8 @@ class _AmazingIconTwotoneFg {
   /// Icon data for monitorFg icon.
   static const IconData monitorFg = IconData(0xf275, fontFamily: _kFontFam, fontPackage: _kFontPkg);
 
-  /// Icon data for monitorMobbileFg icon.
-  static const IconData monitorMobbileFg = IconData(0xf277, fontFamily: _kFontFam, fontPackage: _kFontPkg);
+  /// Icon data for monitorMobileFg icon.
+  static const IconData monitorMobileFg = IconData(0xf277, fontFamily: _kFontFam, fontPackage: _kFontPkg);
 
   /// Icon data for monitorRecorderFg icon.
   static const IconData monitorRecorderFg = IconData(0xf276, fontFamily: _kFontFam, fontPackage: _kFontPkg);
@@ -1793,8 +1793,8 @@ class _AmazingIconTwotoneFg {
   /// Icon data for musicLibrary2Fg icon.
   static const IconData musicLibrary2Fg = IconData(0xf269, fontFamily: _kFontFam, fontPackage: _kFontPkg);
 
-  /// Icon data for musicnoteFg icon.
-  static const IconData musicnoteFg = IconData(0xf261, fontFamily: _kFontFam, fontPackage: _kFontPkg);
+  /// Icon data for musicNoteFg icon.
+  static const IconData musicNoteFg = IconData(0xf261, fontFamily: _kFontFam, fontPackage: _kFontPkg);
 
   /// Icon data for musicPlayFg icon.
   static const IconData musicPlayFg = IconData(0xf268, fontFamily: _kFontFam, fontPackage: _kFontPkg);
@@ -1946,8 +1946,8 @@ class _AmazingIconTwotoneFg {
   /// Icon data for petFg icon.
   static const IconData petFg = IconData(0xf235, fontFamily: _kFontFam, fontPackage: _kFontPkg);
 
-  /// Icon data for pharagraphspacingFg icon.
-  static const IconData pharagraphspacingFg = IconData(0xf234, fontFamily: _kFontFam, fontPackage: _kFontPkg);
+  /// Icon data for paragraphSpacingFg icon.
+  static const IconData paragraphSpacingFg = IconData(0xf234, fontFamily: _kFontFam, fontPackage: _kFontPkg);
 
   /// Icon data for photoshopFg icon.
   static const IconData photoshopFg = IconData(0xf233, fontFamily: _kFontFam, fontPackage: _kFontPkg);
@@ -1961,8 +1961,8 @@ class _AmazingIconTwotoneFg {
   /// Icon data for playCircleFg icon.
   static const IconData playCircleFg = IconData(0xf230, fontFamily: _kFontFam, fontPackage: _kFontPkg);
 
-  /// Icon data for playCricleFg icon.
-  static const IconData playCricleFg = IconData(0xf22f, fontFamily: _kFontFam, fontPackage: _kFontPkg);
+  /// Icon data for playCircle2Fg icon.
+  static const IconData playCircle2Fg = IconData(0xf22f, fontFamily: _kFontFam, fontPackage: _kFontPkg);
 
   /// Icon data for playRemoveFg icon.
   static const IconData playRemoveFg = IconData(0xf22e, fontFamily: _kFontFam, fontPackage: _kFontPkg);
@@ -1976,8 +1976,8 @@ class _AmazingIconTwotoneFg {
   /// Icon data for polyswarmFg icon.
   static const IconData polyswarmFg = IconData(0xf22b, fontFamily: _kFontFam, fontPackage: _kFontPkg);
 
-  /// Icon data for presentionChartFg icon.
-  static const IconData presentionChartFg = IconData(0xf22a, fontFamily: _kFontFam, fontPackage: _kFontPkg);
+  /// Icon data for presentationChartFg icon.
+  static const IconData presentationChartFg = IconData(0xf22a, fontFamily: _kFontFam, fontPackage: _kFontPkg);
 
   /// Icon data for previousFg icon.
   static const IconData previousFg = IconData(0xf229, fontFamily: _kFontFam, fontPackage: _kFontPkg);
@@ -2141,11 +2141,11 @@ class _AmazingIconTwotoneFg {
   /// Icon data for repeatCircleFg icon.
   static const IconData repeatCircleFg = IconData(0xf1f5, fontFamily: _kFontFam, fontPackage: _kFontPkg);
 
-  /// Icon data for repeateMusicFg icon.
-  static const IconData repeateMusicFg = IconData(0xf1f3, fontFamily: _kFontFam, fontPackage: _kFontPkg);
+  /// Icon data for repeatMusicFg icon.
+  static const IconData repeatMusicFg = IconData(0xf1f3, fontFamily: _kFontFam, fontPackage: _kFontPkg);
 
-  /// Icon data for repeateOneFg icon.
-  static const IconData repeateOneFg = IconData(0xf1f2, fontFamily: _kFontFam, fontPackage: _kFontPkg);
+  /// Icon data for repeatOneFg icon.
+  static const IconData repeatOneFg = IconData(0xf1f2, fontFamily: _kFontFam, fontPackage: _kFontPkg);
 
   /// Icon data for reserveFg icon.
   static const IconData reserveFg = IconData(0xf1f1, fontFamily: _kFontFam, fontPackage: _kFontPkg);
@@ -2285,8 +2285,8 @@ class _AmazingIconTwotoneFg {
   /// Icon data for send2Fg icon.
   static const IconData send2Fg = IconData(0xf1c5, fontFamily: _kFontFam, fontPackage: _kFontPkg);
 
-  /// Icon data for sendSqaure2Fg icon.
-  static const IconData sendSqaure2Fg = IconData(0xf1c4, fontFamily: _kFontFam, fontPackage: _kFontPkg);
+  /// Icon data for sendSquare2Fg icon.
+  static const IconData sendSquare2Fg = IconData(0xf1c4, fontFamily: _kFontFam, fontPackage: _kFontPkg);
 
   /// Icon data for sendSquareFg icon.
   static const IconData sendSquareFg = IconData(0xf1c3, fontFamily: _kFontFam, fontPackage: _kFontPkg);
@@ -3210,7 +3210,7 @@ class _AmazingIconTwotoneFg {
     'filterSearchFg': filterSearchFg,
     'filterSquareFg': filterSquareFg,
     'filterTickFg': filterTickFg,
-    'fingerCricleFg': fingerCricleFg,
+    'fingerCircleFg': fingerCircleFg,
     'fingerScanFg': fingerScanFg,
     'firstlineFg': firstlineFg,
     'flagFg': flagFg,
@@ -3278,7 +3278,7 @@ class _AmazingIconTwotoneFg {
     'gridEditFg': gridEditFg,
     'gridEraserFg': gridEraserFg,
     'gridLockFg': gridLockFg,
-    'happyemojiFg': happyemojiFg,
+    'happyEmojiFg': happyEmojiFg,
     'harmonyFg': harmonyFg,
     'hashtagFg': hashtagFg,
     'hashtag1Fg': hashtag1Fg,
@@ -3428,8 +3428,8 @@ class _AmazingIconTwotoneFg {
     'microphoneSlash1Fg': microphoneSlash1Fg,
     'microscopeFg': microscopeFg,
     'milkFg': milkFg,
-    'miniMusicSqaureFg': miniMusicSqaureFg,
-    'minusCirlceFg': minusCirlceFg,
+    'miniMusicSquareFg': miniMusicSquareFg,
+    'minusCircleFg': minusCircleFg,
     'minusSquareFg': minusSquareFg,
     'mirrorFg': mirrorFg,
     'mirroringScreenFg': mirroringScreenFg,
@@ -3450,7 +3450,7 @@ class _AmazingIconTwotoneFg {
     'moneyTimeFg': moneyTimeFg,
     'moneysFg': moneysFg,
     'monitorFg': monitorFg,
-    'monitorMobbileFg': monitorMobbileFg,
+    'monitorMobileFg': monitorMobileFg,
     'monitorRecorderFg': monitorRecorderFg,
     'moreFg': moreFg,
     'more2Fg': more2Fg,
@@ -3471,7 +3471,7 @@ class _AmazingIconTwotoneFg {
     'musicSquareAddFg': musicSquareAddFg,
     'musicSquareRemoveFg': musicSquareRemoveFg,
     'musicSquareSearchFg': musicSquareSearchFg,
-    'musicnoteFg': musicnoteFg,
+    'musicNoteFg': musicNoteFg,
     'nebulasFg': nebulasFg,
     'nemFg': nemFg,
     'nexoFg': nexoFg,
@@ -3516,17 +3516,17 @@ class _AmazingIconTwotoneFg {
     'percentageSquareFg': percentageSquareFg,
     'personalcardFg': personalcardFg,
     'petFg': petFg,
-    'pharagraphspacingFg': pharagraphspacingFg,
+    'paragraphSpacingFg': paragraphSpacingFg,
     'photoshopFg': photoshopFg,
     'pictureFrameFg': pictureFrameFg,
     'playAddFg': playAddFg,
     'playCircleFg': playCircleFg,
-    'playCricleFg': playCricleFg,
+    'playCircle2Fg': playCircle2Fg,
     'playRemoveFg': playRemoveFg,
     'polkadotFg': polkadotFg,
     'polygonFg': polygonFg,
     'polyswarmFg': polyswarmFg,
-    'presentionChartFg': presentionChartFg,
+    'presentationChartFg': presentationChartFg,
     'previousFg': previousFg,
     'printerFg': printerFg,
     'printerSlashFg': printerSlashFg,
@@ -3581,8 +3581,8 @@ class _AmazingIconTwotoneFg {
     'refreshSquare2Fg': refreshSquare2Fg,
     'repeatFg': repeatFg,
     'repeatCircleFg': repeatCircleFg,
-    'repeateMusicFg': repeateMusicFg,
-    'repeateOneFg': repeateOneFg,
+    'repeatMusicFg': repeatMusicFg,
+    'repeatOneFg': repeatOneFg,
     'reserveFg': reserveFg,
     'rotate3dFg': rotate3dFg,
     'rotateLeftFg': rotateLeftFg,
@@ -3629,7 +3629,7 @@ class _AmazingIconTwotoneFg {
     'sendFg': sendFg,
     'send1Fg': send1Fg,
     'send2Fg': send2Fg,
-    'sendSqaure2Fg': sendSqaure2Fg,
+    'sendSquare2Fg': sendSquare2Fg,
     'sendSquareFg': sendSquareFg,
     'settingFg': settingFg,
     'setting2Fg': setting2Fg,


### PR DESCRIPTION
Hey @O-Nicks , 
I found some other typos here: 
- fingerCricle -> fingerCircle
- happyemoji  -> happyEmoji
- miniMusicSqaure -> miniMusicSquare
- minusCirlce -> minusCircle
- monitorMobbile -> monitorMobile
- musicnote -> musicNote
- pharagraphspacing -> paragraphSpacing
- playCricle -> playCircle2 (playCircle already exists)
- presentionChart -> presentationChart
- repeateMusic -> repeatMusic
- repeateOne -> repeatOne
- sendSqaure2 -> sendSquare2

And tests are running 👍

Let me know if I missed anything 🤓
Thanks a lot!